### PR TITLE
Fixed length output confusion in common reads and fixed copy paste er…

### DIFF
--- a/Cut-Trim/src/cut_trim.h
+++ b/Cut-Trim/src/cut_trim.h
@@ -20,7 +20,7 @@ void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe,
         PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());        
         if (per) {
             Read &rb1 = per->non_const_read_one();
-            Read &rb2 = per->non_const_read_one();
+            Read &rb2 = per->non_const_read_two();
             if (!no_left) {
                 rb1.setLCut(cut_size);
                 rb2.setLCut(cut_size);

--- a/common/src/read.cpp
+++ b/common/src/read.cpp
@@ -88,20 +88,24 @@ char Read::complement(char bp) {
 }
 
 void PairedEndRead::setStats(Counter &c) { //Could take stats on one that is discard PE_OUt is not incremented here
-    c["R1_Length"] += one.getLengthTrue();
-    c["R2_Length"] += two.getLengthTrue();
+    if (!one.getDiscard()) {
+        c["R1_Length"] += one.getLengthTrue();
+        c["R1_Left_Trim"] += one.getLTrim();
+        c["R1_Right_Trim"] += one.getRTrim();
+    }
+    if (!two.getDiscard()) {
+        c["R2_Length"] += two.getLengthTrue();
+        c["R2_Left_Trim"] += two.getLTrim();
+        c["R2_Right_Trim"] += two.getRTrim(); 
+    }
 
-    c["R1_Left_Trim"] += one.getLTrim();
-    c["R2_Left_Trim"] += two.getLTrim();
-
-    c["R1_Right_Trim"] += one.getRTrim();
-    c["R2_Right_Trim"] += two.getRTrim(); 
 }
 
 void SingleEndRead::setStats(Counter &c) {
-    c["SE_Length"] += one.getLengthTrue();
-    c["SE_Left_Trim"] += one.getLTrim();
-    c["SE_Right_Trim"] += one.getRTrim();
-
+    if (!one.getDiscard()) {
+        c["SE_Length"] += one.getLengthTrue();
+        c["SE_Left_Trim"] += one.getLTrim();
+        c["SE_Right_Trim"] += one.getRTrim();
+    }
 }
 


### PR DESCRIPTION
-Fixes output for stats
-Fixes copy paste error in CutTrim application (R1 was cut twice)