### PR TITLE
static link common and boost libs

### DIFF
--- a/Cut-Trim/CMakeLists.txt
+++ b/Cut-Trim/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/N-Remover/CMakeLists.txt
+++ b/N-Remover/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/Overlapper/CMakeLists.txt
+++ b/Overlapper/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/Phix-Remover/CMakeLists.txt
+++ b/Phix-Remover/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/PolyAT-Trim/CMakeLists.txt
+++ b/PolyAT-Trim/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/Q-Window-Trim/CMakeLists.txt
+++ b/Q-Window-Trim/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/Super-Deduper/CMakeLists.txt
+++ b/Super-Deduper/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/Tab-Converter/CMakeLists.txt
+++ b/Tab-Converter/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 set(PROJECT_LINK_LIBS hts_common)
 link_directories(${CMAKE_BINARY_DIR}/common)
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system program_options iostreams filesystem REQUIRED )
 include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -4,15 +4,14 @@ project (hts_common)
 file(GLOB sources "src/*.cpp")
 message( status "sources: " ${sources})
 
+set(Boost_USE_STATIC_LIBS   ON)
 FIND_PACKAGE( Boost 1.56 COMPONENTS system filesystem iostreams REQUIRED )
 
 set(COMMON_INCLUDES ${CMAKE_SOURCE_DIR}/common/src)
 include_directories(${GTEST_INCLUDE_DIRS} ${Boost_INCLUDE_DIR} ${COMMON_INCLUDES} )
 
-add_library(${PROJECT_NAME} SHARED ${sources})
+add_library(${PROJECT_NAME} STATIC ${sources})
 target_link_libraries(${PROJECT_NAME}  ${Boost_LIBRARIES})
-
-install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)
 
 ## test
 set(PROJECT_TEST_NAME ${PROJECT_NAME}_test)


### PR DESCRIPTION
Seems like making it static didn't change the size much, and should be easier for people to use, no need to install the common lib and mess with the ld paths.