### PR TITLE
Some stats edits

### DIFF
--- a/common/src/counters.h
+++ b/common/src/counters.h
@@ -62,7 +62,7 @@ public:
         } else {
             const SingleEndRead *ser = dynamic_cast<const SingleEndRead *>(&read);
             if (ser) {
-                ++SE_In; 
+                ++SE_In;
             } else {
                 throw std::runtime_error("In utils.h output: read type not valid");
             }
@@ -86,21 +86,21 @@ public:
     }
 
     virtual void write_out() {
-        
+
         initialize_json();
 
         write_labels(generic);
         write_sublabels("Single_end", se);
         write_sublabels("Paired_end", pe);
 
-        finalize_json();        
+        finalize_json();
     }
 
     virtual void initialize_json() {
         std::ifstream testEnd(fStats);
         int end = testEnd.peek();
         testEnd.close();
-        
+
         if (aStats && end != -1) {
             outStats.open(fStats, std::ios::in | std::ios::out); //append
             outStats.seekp(-6, std::ios::end );
@@ -166,7 +166,7 @@ private:
 
 class TrimmingCounters : public Counters {
 
-public: 
+public:
     uint64_t SE_Right_Trim = 0;
     uint64_t SE_Left_Trim = 0;
     uint64_t SE_Discarded = 0;
@@ -174,7 +174,7 @@ public:
     uint64_t R1_Left_Trim = 0;
     uint64_t R1_Right_Trim = 0;
     uint64_t R2_Left_Trim = 0;
-    uint64_t R2_Right_Trim = 0;    
+    uint64_t R2_Right_Trim = 0;
     uint64_t R1_Discarded = 0;
     uint64_t R2_Discarded = 0;
     uint64_t PE_Discarded = 0;
@@ -217,12 +217,12 @@ public:
             ++PE_Out;
             R1_stats(one);
             R2_stats(two);
-        } else if (!one.getDiscard() && !no_orphans) { //if stranded RC
+        } else if (!one.getDiscard() && !no_orphans) {
             ++TotalFragmentsOutput;
             ++SE_Out;
             ++R2_Discarded;
             SE_stats(one);
-        } else if (!two.getDiscard() && !no_orphans) { // Will never be RC
+        } else if (!two.getDiscard() && !no_orphans) {
             ++TotalFragmentsOutput;
             ++SE_Out;
             ++R1_Discarded;
@@ -242,7 +242,7 @@ public:
             ++SE_Discarded;
         }
     }
-    
+
 };
 
 #endif

--- a/common/src/ioHandler.cpp
+++ b/common/src/ioHandler.cpp
@@ -10,9 +10,9 @@ void writer_helper(ReadBase *r, std::shared_ptr<OutputWriter> pe, std::shared_pt
 
         if (!one.getDiscard() && !two.getDiscard()) {
             pe->write(*per);
-        } else if (!one.getDiscard() && !no_orphans) { //if stranded RC
+        } else if (!one.getDiscard() && !no_orphans) { // Will never be RC
             se->write_read(one, false);
-        } else if (!two.getDiscard() && !no_orphans) { // Will never be RC
+        } else if (!two.getDiscard() && !no_orphans) { // if stranded RC
             se->write_read((per->get_read_two()), stranded);
         } else {
 
@@ -20,7 +20,7 @@ void writer_helper(ReadBase *r, std::shared_ptr<OutputWriter> pe, std::shared_pt
     } else {
         SingleEndRead *ser = dynamic_cast<SingleEndRead*>(r);
         if (!ser) {
-            throw std::runtime_error("Unknow read found");
+            throw std::runtime_error("Unknown read found");
         }
         if (! (ser->non_const_read_one()).getDiscard() ) {
             se->write(*ser);

--- a/common/src/version.h
+++ b/common/src/version.h
@@ -1,6 +1,5 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "0.3.0"
+#define VERSION "0.3.1"
 #endif
-

--- a/hts_CutTrim/src/hts_CutTrim.h
+++ b/hts_CutTrim/src/hts_CutTrim.h
@@ -19,19 +19,19 @@ extern template class InputReader<ReadBase, TabReadImpl>;
 /*
 cut_trim expected behavior:
 cut_trim is expected to be one of the first apps used in a preprocessing pipeline
-such as when you want to statically trim off X bases from the end of a read (cut_right), due to 
+such as when you want to statically trim off X bases from the end of a read (cut_right), due to
 quality, and/or to trim off primer sequence from the beginning of a read (cut_left). As such both
 cut_left and cut_right should act on the original length of the read.
 
 max_length then prevents the final cut length from being greater than max_length applying an
 additional cut to end of the read if applicable. If one wished to simulate smaller sized reads
-can run cut_trim with max_length (no cut to left or right) to effectively reduce the size of reads. 
+can run cut_trim with max_length (no cut to left or right) to effectively reduce the size of reads.
  */
 void cut_trim(Read &r, size_t cut_left, size_t cut_right, size_t max_length) {
     if (cut_left) {
         r.setLCut(cut_left);
     }
-    if (cut_right) { 
+    if (cut_right) {
         r.setRCut(r.getLength() - cut_right);
     }
     if (max_length && max_length < r.getLengthTrue()) {
@@ -44,22 +44,22 @@ template <class T, class Impl>
 void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, TrimmingCounters& counters, size_t min_length , bool stranded, bool no_orphans, size_t r1_cut_left, size_t r1_cut_right, size_t r2_cut_left, size_t r2_cut_right, size_t max_length ){
     while(reader.has_next()) {
         auto i = reader.next();
-        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());        
+        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());
         if (per) {
             counters.input(*per);
             cut_trim( per->non_const_read_one(), r1_cut_left, r1_cut_right, max_length);
             cut_trim( per->non_const_read_two(), r2_cut_left, r2_cut_right, max_length);
-            counters.output(*per);
             per->checkDiscarded(min_length);
             writer_helper(per, pe, se, stranded, no_orphans);
+            counters.output(*per, no_orphans);
         } else {
             SingleEndRead* ser = dynamic_cast<SingleEndRead*>(i.get());
             if (ser) {
                 counters.input(*ser);
                 cut_trim( ser->non_const_read_one(), r1_cut_left, r1_cut_right, max_length);
                 ser->checkDiscarded(min_length);
+                writer_helper(ser, pe, se, false, false);
                 counters.output(*ser);
-                writer_helper(ser, pe, se);
             } else {
                 throw std::runtime_error("Unknown read type");
             }

--- a/hts_NTrimmer/src/hts_NTrimmer.cpp
+++ b/hts_NTrimmer/src/hts_NTrimmer.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
 {
 
     const std::string program_name = "hts_NTrimmer";
-    std::string app_description = 
+    std::string app_description =
                        "The hts_NTrimmer application will identify and return the longest\n";
     app_description += "  subsequence that no N characters appear in.\n";
 
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
 
             /** --help option
              */
-            version_or_help(program_name, app_description, cmdline_options, vm); 
+            version_or_help(program_name, app_description, cmdline_options, vm);
             po::notify(vm); // throws on error, so do after help in case
 
             std::string statsFile(vm["stats-file"].as<std::string>());
@@ -84,7 +84,7 @@ int main(int argc, char** argv)
                 }
                 auto read1_files = vm["read1-input"].as<std::vector<std::string> >();
                 auto read2_files = vm["read2-input"].as<std::vector<std::string> >();
-                
+
                 if (read1_files.size() != read2_files.size()) {
                     throw std::runtime_error("must have same number of input files for read1 and read2");
                 }
@@ -92,9 +92,9 @@ int main(int argc, char** argv)
                 for(size_t i = 0; i < read1_files.size(); ++i) {
                     bi::stream<bi::file_descriptor_source> is1{check_open_r(read1_files[i]), bi::close_handle};
                     bi::stream<bi::file_descriptor_source> is2{check_open_r(read2_files[i]), bi::close_handle};
-                   
+
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
-                    helper_trim(ifp, pe, se, counters, vm["stranded"].as<bool>() , vm["min-length"].as<size_t>() );
+                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
             }
 
@@ -103,33 +103,33 @@ int main(int argc, char** argv)
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
-                    helper_trim(ifs, pe, se, counters, vm["stranded"].as<bool>() , vm["min-length"].as<size_t>() );
+                    helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
             }
-            
+
             if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
-                    helper_trim(ift, pe, se, counters, vm["stranded"].as<bool>() , vm["min-length"].as<size_t>() );
+                    helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
             }
-            
+
             if (vm.count("interleaved-input")) {
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
-                    helper_trim(ifp, pe, se, counters, vm["stranded"].as<bool>() , vm["min-length"].as<size_t>() );
+                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
             }
-           
+
             if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
-                helper_trim(ift, pe, se, counters, vm["stranded"].as<bool>() , vm["min-length"].as<size_t>() );
-            }  
+                helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+            }
             counters.write_out();
         }
         catch(po::error& e)

--- a/hts_NTrimmer/src/hts_NTrimmer.h
+++ b/hts_NTrimmer/src/hts_NTrimmer.h
@@ -17,7 +17,7 @@ extern template class InputReader<PairedEndRead, InterReadImpl>;
 extern template class InputReader<ReadBase, TabReadImpl>;
 
 size_t dist(size_t x, size_t y) {
-    assert(x <= y); 
+    assert(x <= y);
     return y - x;
 }
 
@@ -25,14 +25,14 @@ size_t dist(size_t x, size_t y) {
  * it will search for the longest base pair segment that has
  * no N's within it*/
 void trim_n(Read &rb) {
-    
+
     std::string seq = rb.get_seq();
     size_t bestLeft = 0, currentLeft = 0, bestRight = 0;
     size_t i = 0;
 
     for (std::string::iterator it = seq.begin(); it != seq.end(); ++it) {
         i = static_cast<size_t>(it - seq.begin() );
-        
+
         if (*it == 'N') {
             currentLeft = i + 1;
         } else if (dist(bestLeft, bestRight) < dist(currentLeft, i)) {
@@ -47,27 +47,26 @@ void trim_n(Read &rb) {
 
 /*Removes all Ns (ambiguity base) from a read*/
 template <class T, class Impl>
-void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, TrimmingCounters& counters, bool stranded, size_t min_length) {
-    
+void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, TrimmingCounters& counters, size_t min_length , bool stranded, bool no_orphans) {
+
     while(reader.has_next()) {
         auto i = reader.next();
-        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());        
+        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());
         if (per) {
             counters.input(*per);
-            trim_n(per->non_const_read_one());            
-            trim_n(per->non_const_read_two()); 
+            trim_n(per->non_const_read_one());
+            trim_n(per->non_const_read_two());
             per->checkDiscarded(min_length);
-            counters.output(*per);
-            writer_helper(per, pe, se, stranded);
+            writer_helper(per, pe, se, stranded, no_orphans);
+            counters.output(*per, no_orphans);
         } else {
             SingleEndRead* ser = dynamic_cast<SingleEndRead*>(i.get());
-            
             if (ser) {
                 counters.input(*ser);
                 trim_n(ser->non_const_read_one());
                 ser->checkDiscarded(min_length);
+                writer_helper(ser, pe, se, false, false);
                 counters.output(*ser);
-                writer_helper(ser, pe, se, stranded);
             } else {
                 throw std::runtime_error("Unknow read type");
             }

--- a/hts_PolyATTrim/src/hts_PolyATTrim.h
+++ b/hts_PolyATTrim/src/hts_PolyATTrim.h
@@ -22,7 +22,7 @@ void trim_left(Read &rb, size_t min_trim, size_t max_mismatch) {
 
     std::string seq = rb.get_seq();
     std::string::iterator current_loc, tmp_loc = seq.begin();
-    
+
     for (current_loc = seq.begin(); current_loc != seq.end() ; ++current_loc ) {
         if ( *current_loc != 'A' ) {
             ++a_mismatch;
@@ -35,13 +35,13 @@ void trim_left(Read &rb, size_t min_trim, size_t max_mismatch) {
             tmp_loc = current_loc;
         }
         if (t_mismatch >= max_mismatch && a_mismatch >= max_mismatch) {
-            break;    
+            break;
         }
     }
     if (tmp_loc - seq.begin() + 1 >= static_cast<long> (min_trim) ) { //+1 for 0 condtion
         rb.setLCut( static_cast<size_t>(  (tmp_loc) - (seq.begin()) ) + 1 );
     }
- 
+
 }
 
 void trim_right(Read &rb, size_t min_trim, size_t max_mismatch) {
@@ -50,7 +50,7 @@ void trim_right(Read &rb, size_t min_trim, size_t max_mismatch) {
 
     std::string seq = rb.get_seq();
     std::string::reverse_iterator current_loc, tmp_loc = seq.rbegin();
-    
+
     for (current_loc = seq.rbegin(); current_loc != seq.rend() ; ++current_loc ) {
         if ( *current_loc != 'A' ) {
             ++a_mismatch;
@@ -63,7 +63,7 @@ void trim_right(Read &rb, size_t min_trim, size_t max_mismatch) {
             tmp_loc = current_loc;
         }
         if (t_mismatch >= max_mismatch && a_mismatch >= max_mismatch) {
-            break;    
+            break;
         }
     }
     if (tmp_loc - seq.rbegin() + 1 >= static_cast<long> (min_trim) && seq.rend() > tmp_loc ) {
@@ -73,37 +73,37 @@ void trim_right(Read &rb, size_t min_trim, size_t max_mismatch) {
 
 template <class T, class Impl>
 void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, TrimmingCounters& counters, size_t min_length, size_t min_trim, size_t max_mismatch, bool stranded, bool no_left, bool no_right, bool no_orphans) {
-    
+
     while(reader.has_next()) {
         auto i = reader.next();
-        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());        
+        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());
         if (per) {
             counters.input(*per);
             if (!no_left) {
                 trim_left(per->non_const_read_one(), min_trim, max_mismatch);
-                trim_left(per->non_const_read_two(), min_trim, max_mismatch);            
+                trim_left(per->non_const_read_two(), min_trim, max_mismatch);
             }
             if (!no_right) {
                 trim_right(per->non_const_read_one(), min_trim, max_mismatch);
-                trim_right(per->non_const_read_two(), min_trim, max_mismatch);            
+                trim_right(per->non_const_read_two(), min_trim, max_mismatch);
             }
             per->checkDiscarded(min_length);
-            counters.output(*per, no_orphans);
             writer_helper(per, pe, se, stranded, no_orphans);
+            counters.output(*per, no_orphans);
         } else {
             SingleEndRead* ser = dynamic_cast<SingleEndRead*>(i.get());
-            
+
             if (ser) {
                 counters.input(*ser);
                 if (!no_left) {
-                    trim_left(ser->non_const_read_one(), min_trim, max_mismatch);            
-                } 
+                    trim_left(ser->non_const_read_one(), min_trim, max_mismatch);
+                }
                 if (!no_right) {
-                    trim_right(ser->non_const_read_one(), min_trim, max_mismatch);            
+                    trim_right(ser->non_const_read_one(), min_trim, max_mismatch);
                 }
                 ser->checkDiscarded(min_length);
-                counters.output(*ser); 
-                writer_helper(ser, pe, se, stranded, no_orphans);
+                writer_helper(ser, pe, se, false, false);
+                counters.output(*ser);
             } else {
                 throw std::runtime_error("Unknow read type");
             }

--- a/hts_QWindowTrim/src/hts_QWindowTrim.cpp
+++ b/hts_QWindowTrim/src/hts_QWindowTrim.cpp
@@ -32,7 +32,7 @@ namespace bi = boost::iostreams;
 int main(int argc, char** argv)
 {
     const std::string program_name = "hts_QWindowTrim";
-    std::string app_description = 
+    std::string app_description =
                        "hts_QWindowTrim uses a sliding window approach to remove low quality\n";
     app_description += "  bases (5' or 3') from a read. A window will slide from each end of the\n";
     app_description += "  read, moving inwards. Once the window reaches an average quality <avg-qual>\n";
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
 
         setDefaultParamsCutting(desc);
             // no-orphans|n ; stranded|s ; min-length|m
-        setDefaultParamsTrim(desc); 
+        setDefaultParamsTrim(desc);
             // no-left|l ; no-right|r
 
         desc.add_options()
@@ -73,17 +73,17 @@ int main(int argc, char** argv)
         {
             po::store(po::parse_command_line(argc, argv, cmdline_options),
                       vm); // can throw
-           
-            version_or_help(program_name, app_description, cmdline_options, vm); 
+
+            version_or_help(program_name, app_description, cmdline_options, vm);
 
             po::notify(vm); // throws on error, so do after help in case
-           
-             
+
+
             size_t qual_threshold = vm["avg-qual"].as<size_t>() + vm["qual-offset"].as<size_t>() ;
 
             std::string statsFile(vm["stats-file"].as<std::string>());
             std::string prefix(vm["prefix"].as<std::string>());
-    
+
             std::shared_ptr<OutputWriter> pe = nullptr;
             std::shared_ptr<OutputWriter> se = nullptr;
 
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
                 }
                 auto read1_files = vm["read1-input"].as<std::vector<std::string> >();
                 auto read2_files = vm["read2-input"].as<std::vector<std::string> >();
-                
+
                 if (read1_files.size() != read2_files.size()) {
                     throw std::runtime_error("must have same number of input files for read1 and read2");
                 }
@@ -105,9 +105,9 @@ int main(int argc, char** argv)
                 for(size_t i = 0; i < read1_files.size(); ++i) {
                     bi::stream<bi::file_descriptor_source> is1{check_open_r(read1_files[i]), bi::close_handle};
                     bi::stream<bi::file_descriptor_source> is2{check_open_r(read2_files[i]), bi::close_handle};
-                   
+
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
-                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , qual_threshold, vm["window-size"].as<size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
             }
 
@@ -116,33 +116,33 @@ int main(int argc, char** argv)
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
-                    helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , qual_threshold, vm["window-size"].as<size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
             }
-            
+
             if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
-                    helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , qual_threshold, vm["window-size"].as<size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
             }
-            
+
             if (vm.count("interleaved-input")) {
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
-                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , qual_threshold, vm["window-size"].as<size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
             }
-           
+
             if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
-                helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , qual_threshold, vm["window-size"].as<size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
-            }  
+                helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
+            }
             counters.write_out();
         }
         catch(po::error& e)

--- a/hts_QWindowTrim/src/hts_QWindowTrim.h
+++ b/hts_QWindowTrim/src/hts_QWindowTrim.h
@@ -88,7 +88,7 @@ void trim_right(Read &rb, size_t qual_threshold, size_t window_size) {
 }
 
 template <class T, class Impl>
-void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, TrimmingCounters &counters, size_t min_length, size_t qual_threshold, size_t window_size, bool stranded, bool no_left, bool no_right, bool no_orphans) {
+void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, TrimmingCounters &counters, size_t min_length, bool stranded, bool no_orphans, size_t qual_threshold, size_t window_size, bool no_left, bool no_right) {
 
     while(reader.has_next()) {
         auto i = reader.next();
@@ -105,7 +105,7 @@ void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe,
             }
             per->checkDiscarded(min_length);
             writer_helper(per, pe, se, stranded, no_orphans);
-            counters.output(*per);
+            counters.output(*per, no_orphans);
         } else {
             SingleEndRead* ser = dynamic_cast<SingleEndRead*>(i.get());
 

--- a/hts_QWindowTrim/src/hts_QWindowTrim.h
+++ b/hts_QWindowTrim/src/hts_QWindowTrim.h
@@ -42,7 +42,7 @@ void trim_left(Read &rb, size_t qual_threshold, size_t window_size) {
             cut = i ;
         }
     }
-    
+
     if (current_sum < sum_qual) {
         rb.setLCut(qual.length() - 1);
     } else {
@@ -70,7 +70,7 @@ void trim_right(Read &rb, size_t qual_threshold, size_t window_size) {
         } else {
             sum_qual = i * qual_threshold;
         }
-        
+
         if (current_sum >= sum_qual) {
             break;
         } else {
@@ -84,20 +84,20 @@ void trim_right(Read &rb, size_t qual_threshold, size_t window_size) {
     } else {
         rb.setRCut(len - cut);
     }
- 
+
 }
 
 template <class T, class Impl>
 void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, TrimmingCounters &counters, size_t min_length, size_t qual_threshold, size_t window_size, bool stranded, bool no_left, bool no_right, bool no_orphans) {
-    
+
     while(reader.has_next()) {
         auto i = reader.next();
-        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());        
+        PairedEndRead* per = dynamic_cast<PairedEndRead*>(i.get());
         if (per) {
             counters.input(*per);
             if (!no_left) {
                 trim_left(per->non_const_read_one(), qual_threshold, window_size);
-                trim_left(per->non_const_read_two(), qual_threshold, window_size);            
+                trim_left(per->non_const_read_two(), qual_threshold, window_size);
             }
             if (!no_right) {
                 trim_right(per->non_const_read_one(), qual_threshold, window_size);
@@ -108,17 +108,17 @@ void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe,
             counters.output(*per);
         } else {
             SingleEndRead* ser = dynamic_cast<SingleEndRead*>(i.get());
-            
+
             if (ser) {
                 counters.input(*ser);
                 if (!no_left) {
-                    trim_left(ser->non_const_read_one(), qual_threshold, window_size);            
-                } 
+                    trim_left(ser->non_const_read_one(), qual_threshold, window_size);
+                }
                 if (!no_right) {
-                    trim_right(ser->non_const_read_one(), qual_threshold, window_size);            
+                    trim_right(ser->non_const_read_one(), qual_threshold, window_size);
                 }
                 ser->checkDiscarded(min_length);
-                writer_helper(ser, pe, se, stranded);
+                writer_helper(ser, pe, se, false, false);
                 counters.output(*ser);
             } else {
                 throw std::runtime_error("Unknow read type");

--- a/hts_SuperDeduper/src/hts_SuperDeduper.h
+++ b/hts_SuperDeduper/src/hts_SuperDeduper.h
@@ -31,7 +31,7 @@ public:
     using Counters::input;
     virtual void input(const ReadBase &read, size_t dup_freq) {
         if (dup_freq > 0 && TotalFragmentsInput % dup_freq == 0 && TotalFragmentsInput != 0){
-            duplicateProportion.push_back(std::forward_as_tuple(TotalFragmentsInput, TotalFragmentsOutput));
+            duplicateProportion.push_back(std::forward_as_tuple(TotalFragmentsInput, Duplicate));
         }
         Counters::input(read);
     }
@@ -47,7 +47,7 @@ public:
     virtual void write_out() {
 
         // record final input/dup
-        duplicateProportion.push_back(std::forward_as_tuple(TotalFragmentsInput, TotalFragmentsOutput));
+        duplicateProportion.push_back(std::forward_as_tuple(TotalFragmentsInput, Duplicate));
 
         initialize_json();
 


### PR DESCRIPTION
There were a number of things fixed
1) no_orphans left off as option in Qwindow, option was there, but didn't get passed to function.
2) did some standardizations, re: how stats were generated, so apps looks similar
3) changed output of SD saturation, prior output created weird results since SD retains reads until the end that don't meet W threshold, changed to outputing discard instead of output

No changes resulted in algorithm changes, output is identical (verified) to before, but stats is more right