### PR TITLE
Added ability for ambiguity bases in SeqScreener, added check for res…

### DIFF
--- a/common/src/version.h
+++ b/common/src/version.h
@@ -1,5 +1,5 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "0.3.1"
+#define VERSION "0.3.2"
 #endif

--- a/hts_SeqScreener/src/hts_SeqScreener.h
+++ b/hts_SeqScreener/src/hts_SeqScreener.h
@@ -25,9 +25,14 @@ extern template class InputReader<PairedEndRead, PairedEndReadFastqImpl>;
 extern template class InputReader<PairedEndRead, InterReadImpl>;
 extern template class InputReader<ReadBase, TabReadImpl>;
 
-class PhixCounters : public Counters {
+class SeqScreenerCounters : public Counters {
 
 public:
+    std::string screen_file;
+    uint64_t screen_bp = 0;
+    uint64_t lookup_kmers = 0;
+    std::vector<Label> screened_info;
+
     uint64_t Inverse = 0;
     uint64_t Record = 0;
 
@@ -35,15 +40,25 @@ public:
 
     uint64_t PE_hits = 0;
 
-    PhixCounters(const std::string &statsFile, bool appendStats, const std::string &program_name, const std::string &notes) : Counters::Counters(statsFile, appendStats, program_name, notes) {
+    SeqScreenerCounters(const std::string &statsFile, bool appendStats, const std::string &program_name, const std::string &notes) : Counters::Counters(statsFile, appendStats, program_name, notes) {
         generic.push_back(std::forward_as_tuple("inverse", Inverse));
         generic.push_back(std::forward_as_tuple("record", Record));
 
         se.push_back(std::forward_as_tuple("SE_hits", SE_hits));
 
         pe.push_back(std::forward_as_tuple("PE_hits", PE_hits));
+        // Need to and in screen_file name, however its a string and the vector can't have mixed types.
+        //screened_info.push_back(std::forward_as_tuple("screenFile", screen_file));
+        screened_info.push_back(std::forward_as_tuple("screenBP", screen_bp));
+        screened_info.push_back(std::forward_as_tuple("lookupKmers", lookup_kmers));
+
     }
 
+    void set_screeninfo(const std::string &screenFile, uint64_t sbp, uint64_t lkmers) {
+        screen_file = screenFile;
+        screen_bp = sbp;
+        lookup_kmers = lkmers;
+    }
     void set_inverse() {
         Inverse = 1;
     }
@@ -55,6 +70,17 @@ public:
     }
     void inc_PE_hits() {
         ++PE_hits;
+    }
+    virtual void write_out() {
+
+        initialize_json();
+
+        write_labels(generic);
+        write_sublabels("Screen_info", screened_info);
+        write_sublabels("Single_end", se);
+        write_sublabels("Paired_end", pe);
+
+        finalize_json();
     }
 };
 
@@ -84,7 +110,7 @@ Read fasta_set_to_one_read(InputReader<SingleEndRead, FastaReadImpl> &faReader  
 
 
 std::pair <bool, bool> setBitsChar(char c) {
-    
+
     switch (std::toupper(c)) {
         case 'A':
             return std::pair<bool, bool> (0, 0);
@@ -106,15 +132,15 @@ std::pair <bool, bool> setBitsChar(char c) {
  * Bitsets are safe, all positions will be overwritten without need to reset
  *
  * Two pairs of critical bitsets are at a work forwardLookup and forwardRest AND reverseLookup and reverseRest
- * the *Lookup varaibles are used as a 'prefix search'. 
+ * the *Lookup varaibles are used as a 'prefix search'.
  *      We go to the prefix search location in the hashmap
  *          If diff (meaning the prefix DOES NOT contains all the kmer in the search) AND that location is not null
  *              check the vector at that location for *Rest (the rest of the data that isn't contained in Lookup)
  *              If the vector contains *Rest ++hit
- *                  
+ *
  *          else if !diff (lookup is the same size as KMER) AND that location is not null
  *              ++hit
- * 
+ *
  * return number of hits seen */
 
 unsigned int check_read( kmerSet &lookup, const Read &rb, const size_t bitKmer, const size_t lookup_loc, const size_t lookup_loc_rc, boost::dynamic_bitset<> &forwardLookup, boost::dynamic_bitset<> &reverseLookup) {
@@ -141,7 +167,7 @@ unsigned int check_read( kmerSet &lookup, const Read &rb, const size_t bitKmer, 
      * if there is a "soft hit", initiate a search of the vector with the cooresponding Rest*/
     std::pair <bool, bool> bits;
     for (std::string::iterator bp = seq.begin(); bp < seq.end(); ++bp) { //goes through each bp of the read
-         
+
         if (std::toupper(*bp) == 'N') { // N resets everythign
             current_added = 0;
         } else {
@@ -150,26 +176,26 @@ unsigned int check_read( kmerSet &lookup, const Read &rb, const size_t bitKmer, 
             bits = setBitsChar(*bp);
             forwardLookup[lookup_loc] = bits.first;
             forwardLookup[lookup_loc+1] = bits.second;
-            reverseLookup[lookup_loc_rc ] = !bits.first; 
-            reverseLookup[lookup_loc_rc + 1] = !bits.second; 
-            
+            reverseLookup[lookup_loc_rc ] = !bits.first;
+            reverseLookup[lookup_loc_rc + 1] = !bits.second;
+
             current_added += 2;
-           
+
             if (current_added >= bitKmer) { //initiate hit search
                 boost::dynamic_bitset<> &bs = forwardLookup > reverseLookup ? forwardLookup : reverseLookup;
                 if (lookup.find(bs) != lookup.end()) {
                     ++hits;
                 }
             }
-            
+
          }
     }
 
-    return hits; 
+    return hits;
 }
 
 template <class T, class Impl>
-void helper_discard(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, PhixCounters& c, kmerSet &lookup, double hits, bool checkR2, size_t kmerSize, bool inverse = false, bool record = false) {
+void helper_discard(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe, std::shared_ptr<OutputWriter> se, SeqScreenerCounters& c, kmerSet &lookup, double hits, bool checkR2, size_t kmerSize, bool inverse = false, bool record = false) {
 
     /*These are set here so each read doesn't have to recalcuate these stats*/
 
@@ -192,10 +218,10 @@ void helper_discard(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> 
             c.input(*per);
             double val = check_read(lookup, per->get_read_one(), bitKmer, lookup_loc, lookup_loc_rc, forwardLookup, reverseLookup );
             val = val / ( per->get_read_one().getLength() - kmerSize);
-           
+
             if (checkR2) {
                 double val2 = check_read(lookup, per->get_read_two(), bitKmer, lookup_loc, lookup_loc_rc, forwardLookup, reverseLookup );
-                
+
                 val2 = val2 / (per->get_read_one().getLength() - kmerSize);
                 val = std::max(val, val2);
             }
@@ -209,7 +235,7 @@ void helper_discard(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> 
             } else if (val > hits && inverse && !record) {
                 c.output(*per);
                 writer_helper(per, pe, se, false);
-            } else if (record) {                
+            } else if (record) {
                 c.output(*per);
                 writer_helper(per, pe, se, false);
             }
@@ -233,7 +259,7 @@ void helper_discard(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> 
                     writer_helper(ser, pe, se, false);
                 } else if (record) {
                     c.output(*ser);
-                    writer_helper(ser, pe, se, false);                    
+                    writer_helper(ser, pe, se, false);
                 }
             } else {
                 throw std::runtime_error("Unknown read type");
@@ -262,11 +288,11 @@ void setLookup( kmerSet &lookup, Read &rb, size_t kmerSize) {
     /*This function is only called once, these values calculation are minimal cost so they are not in the function args*/
     /*Total size of kmer bits*/
     size_t bitKmer = kmerSize * 2;
-   
-    /*lookup locations*/ 
-    size_t lookup_loc = 0; 
+
+    /*lookup locations*/
+    size_t lookup_loc = 0;
     size_t lookup_loc_rc = bitKmer - 2;
-    
+
     size_t current_added = 0;
     boost::dynamic_bitset <> forwardLookup(bitKmer);
     boost::dynamic_bitset <> reverseLookup(bitKmer);
@@ -274,12 +300,10 @@ void setLookup( kmerSet &lookup, Read &rb, size_t kmerSize) {
     std::string seq = rb.get_seq();
     std::pair<bool, bool> bits;
     for (std::string::iterator bp = seq.begin(); bp != seq.end(); ++bp) {
-        if (std::toupper(*bp) == 'N' ) { // N
-            current_added = 0;
-        } else {
+        if (std::toupper(*bp) == 'A' || std::toupper(*bp) == 'C' || std::toupper(*bp) == 'G' || std::toupper(*bp) == 'T' ) { // N
             reverseLookup >>= 2;
             forwardLookup <<=2;
-            
+
             bits = setBitsChar(*bp);
             forwardLookup[lookup_loc] = bits.first;
             forwardLookup[lookup_loc + 1] = bits.second;
@@ -289,8 +313,9 @@ void setLookup( kmerSet &lookup, Read &rb, size_t kmerSize) {
             if (current_added >= bitKmer) {
                 boost::dynamic_bitset<> &bs = forwardLookup > reverseLookup ? forwardLookup : reverseLookup;
                 lookup.insert(bs);
-            } 
-            
+            }
+         } else {
+           current_added = 0;
          }
     }
 

--- a/hts_SeqScreener/test/hts_TestSeqScreener.cpp
+++ b/hts_SeqScreener/test/hts_TestSeqScreener.cpp
@@ -3,14 +3,14 @@
 #include <iostream>
 #include "hts_SeqScreener.h"
 
-class PhixRemover : public ::testing::Test {
+class SeqScreener : public ::testing::Test {
     public:
         const std::string phixTest = "ACTGACTGACTGACTGACTGACTGACTG";
         const std::string readData_1 = "@R1\nAAAAACTGACTGACTGTTTT\n+\nAAAAACTGACTGACTGTTTT\n";
         const size_t lookup_kmer_test = 2;
 };
 
-TEST_F(PhixRemover, all_from_fastq) {
+TEST_F(SeqScreener, all_from_fastq) {
     const std::string faFile = ">1\nACGT\nACGT\n>2\nTTTT\n";
     std::istringstream fa(faFile);
     InputReader<SingleEndRead, FastaReadImpl> f(fa);
@@ -19,14 +19,14 @@ TEST_F(PhixRemover, all_from_fastq) {
     ASSERT_EQ("ACGTACGTTTTT", r.get_seq());
 };
 
-TEST_F(PhixRemover, check_check_read) {
+TEST_F(SeqScreener, check_check_read) {
     std::string s("AAAAAAAGCT");
-    Read readPhix = Read(s, "", ""); 
-    Read testRead = Read(s, "", ""); 
-    kmerSet lookup;    
+    Read readPhix = Read(s, "", "");
+    Read testRead = Read(s, "", "");
+    kmerSet lookup;
     size_t true_kmer = 5;
     setLookup(lookup, readPhix, true_kmer);
-    
+
     boost::dynamic_bitset<> fLu(true_kmer * 2);
     boost::dynamic_bitset<> rLu(true_kmer * 2);
     size_t lookup_loc = 0;
@@ -37,24 +37,21 @@ TEST_F(PhixRemover, check_check_read) {
 };;
 
 
-TEST_F(PhixRemover, setLookupTestOrderedVec) {
+TEST_F(SeqScreener, setLookupTestOrderedVec) {
     std::string s("AAAAAAAGCT");
     std::cout << "Testing Building Lookup Table with sequence " << s << '\n';
-    std::cout << "HERE 1\n";
-    Read readPhix = Read(s, "", ""); 
-    std::cout << "HERE 2\n";
+    Read readPhix = Read(s, "", "");
     kmerSet lookup;
-    
+
     setLookup(lookup, readPhix, 5);
-    std::cout << "HERE 3\n";
     std::cout << lookup.size() << '\n';
     ASSERT_EQ(4, lookup.size());
 };
 
-TEST_F(PhixRemover, setLookupTest) {
+TEST_F(SeqScreener, setLookupTest) {
     std::string s("AAAAAAAGCT");
     std::cout << "Testing Building Lookup Table with sequence " << s << '\n';
-    Read readPhix = Read(s, "", ""); 
+    Read readPhix = Read(s, "", "");
     kmerSet lookup;
     setLookup(lookup, readPhix, 5);
     //ASSERT_EQ(true , lookup.end != lookup.find(boost::dynamic_bitset<>(10, "1001111111")))
@@ -62,3 +59,28 @@ TEST_F(PhixRemover, setLookupTest) {
 
 };
 
+TEST_F(SeqScreener, setLookupTestAmbiguities) {
+    std::string s("GAAAAAAGCVM");
+    std::cout << "Testing Building Lookup Table with sequence ambiguities " << s << '\n';
+    Read readAmbiguities = Read(s, "", "");
+    std::cout << "Seq in read " << readAmbiguities.get_seq() << '\n';
+    kmerSet lookup;
+    setLookup(lookup, readAmbiguities, 5);
+    std::cout << "myset contains:";
+    for ( auto it = lookup.begin(); it != lookup.end(); ++it )
+        std::cout << " " << *it;
+    std::cout << std::endl;
+    std::cout << lookup.size() << '\n';
+    ASSERT_EQ(4, lookup.size());
+};
+
+TEST_F(SeqScreener, setLookupTestAmbiguities2_nokmers) {
+    std::string s("GAANAAGCVM");
+    std::cout << "Testing Building Lookup Table with sequence ambiguities " << s << '\n';
+    Read readAmbiguities = Read(s, "", "");
+    std::cout << "Seq in read " << readAmbiguities.get_seq() << '\n';
+    kmerSet lookup;
+    setLookup(lookup, readAmbiguities, 5);
+    std::cout << lookup.size() << '\n';
+    ASSERT_EQ(0, lookup.size());
+};


### PR DESCRIPTION
Deal with issue #134 , came upon it again last week as downloaded sequences from NCBI will often have ambiguities. Some additional cosmetic changes, like add error when lookup table has 0 kmers in it and added new stats section for lookup details bp and kmers, so the users has some idea how many potential kmers have been ignored due to non primary bases (A,C,G,T), ambiguities are treated like Ns and all kmers containing are ignored.