### PR TITLE
rework input/output file requirements, add in error messages when inpu…

### DIFF
--- a/common/src/ioHandler.h
+++ b/common/src/ioHandler.h
@@ -261,9 +261,9 @@ protected:
      * TLEN - SEQ.length
      * SEQ - seq
      * QUAL - qual */
-    const size_t se_bitwise = 68;
-    const size_t pe1_bitwise = 69;
-    const size_t pe2_bitwise = 133;
+    const size_t se_bitwise = 4;
+    const size_t pe1_bitwise = 77;
+    const size_t pe2_bitwise = 141;
 
     void samout(const Read &read, size_t bitwiseflag) {
         *output << read.get_id() << '\t'

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -35,35 +35,30 @@ void outputWriters(std::shared_ptr<OutputWriter> &pe, std::shared_ptr<OutputWrit
     std::shared_ptr<HtsOfstream> out_1 = nullptr;
     std::shared_ptr<HtsOfstream> out_2 = nullptr;
     std::shared_ptr<HtsOfstream> out_3 = nullptr;
-    
-    if (interleaved_out)  {
-        for (auto& outfile: default_outfiles) {
-            outfile = prefix + "INTER" + ".fastq";
-        }
+    const size_t ERROR_IN_COMMAND_LINE = 1;
 
+    if (interleaved_out)  {
+        default_outfiles[0] = prefix + "_interleaved" + ".fastq";
+        default_outfiles[2] = prefix + "_SE" + ".fastq";
         out_1= std::make_shared<HtsOfstream>(default_outfiles[0], force, gzip_out, false);
-        out_3= std::make_shared<HtsOfstream>(default_outfiles[1], force, gzip_out, false);
+        out_3= std::make_shared<HtsOfstream>(default_outfiles[2], force, gzip_out, false);
 
         pe= std::make_shared<PairedEndReadOutInter>(out_1);
         se= std::make_shared<SingleEndReadOutFastq>(out_3);
     } else if (unmapped_out) {
-        for (auto& outfile: default_outfiles) {
-            outfile = prefix + ".sam";
-        }
+        default_outfiles[0] = prefix + ".sam";
         out_1= std::make_shared<HtsOfstream>(default_outfiles[0], force, gzip_out, std_out);
 
         pe= std::make_shared<ReadBaseOutUnmapped>(out_1);
         se= std::make_shared<ReadBaseOutUnmapped>(out_1);
 
     } else if (tab_out || std_out) {
-        for (auto& outfile: default_outfiles) {
-            outfile = prefix + "tab" + ".tastq";
-        }
+        default_outfiles[0] = prefix + "_tab6" + ".fastq";
         out_1= std::make_shared<HtsOfstream>(default_outfiles[0], force, gzip_out, std_out);
 
         pe= std::make_shared<ReadBaseOutTab>(out_1);
         se= std::make_shared<ReadBaseOutTab>(out_1);
-    } else if (fastq_out || (! std_out && ! tab_out) ) {
+    } else if (fastq_out) {
         for (auto& outfile: default_outfiles) {
             outfile = prefix + outfile + ".fastq";
         }
@@ -74,6 +69,9 @@ void outputWriters(std::shared_ptr<OutputWriter> &pe, std::shared_ptr<OutputWrit
 
         pe= std::make_shared<PairedEndReadOutFastq>(out_1, out_2);
         se= std::make_shared<SingleEndReadOutFastq>(out_3);
+    } else {
+        std::cerr << "ERROR: " << "Output file type absent from command line" << std::endl << std::endl;
+        exit(ERROR_IN_COMMAND_LINE); //success
     }
 }
 
@@ -104,7 +102,7 @@ po::options_description setOutputOptions(std::string program_name){
             ("prefix,p", po::value<std::string>()->default_value(program_name),
                                            "Prefix for output files")
             ("gzip-output,g", po::bool_switch()->default_value(false),  "Output gzipped files")
-            ("fastq-output,f", po::bool_switch()->default_value(true), "Output to Fastq format <PE AND/OR SE files>")
+            ("fastq-output,f", po::bool_switch()->default_value(false), "Output to Fastq format <PE AND/OR SE files>")
             ("tab-output,t", po::bool_switch()->default_value(false),   "Output to tab-delimited file format")
             ("interleaved-output,i", po::bool_switch()->default_value(false),     "Output to interleaved fastq file <PE ONLY>")
             ("unmapped-output,u", po::bool_switch()->default_value(false),   "Output to unmapped sam file format")

--- a/hts_CutTrim/src/hts_CutTrim.cpp
+++ b/hts_CutTrim/src/hts_CutTrim.cpp
@@ -31,7 +31,7 @@ namespace bi = boost::iostreams;
 int main(int argc, char** argv)
 {
     const std::string program_name = "hts_CutTrim";
-    std::string app_description = 
+    std::string app_description =
                        "The hts_CutTrim application trims a set number of bases from the 5'\n";
     app_description += "  and/or 3' end of each read\n";
 
@@ -77,18 +77,18 @@ int main(int argc, char** argv)
             /** --help option
              */
             version_or_help(program_name, app_description, cmdline_options, vm);
-            
+
             po::notify(vm); // throws on error, so do after help in case
 
             std::string statsFile(vm["stats-file"].as<std::string>());
             std::string prefix(vm["prefix"].as<std::string>());
-            
+
             std::shared_ptr<OutputWriter> pe = nullptr;
             std::shared_ptr<OutputWriter> se = nullptr;
-            
+
             TrimmingCounters counters(statsFile, vm["append-stats-file"].as<bool>() , program_name, vm["notes"].as<std::string>());
 
-            outputWriters(pe, se, vm["fastq-output"].as<bool>(), vm["tab-output"].as<bool>(), vm["interleaved-output"].as<bool>(), vm["unmapped-output"].as<bool>(), vm["force"].as<bool>(), vm["gzip-output"].as<bool>(), vm["to-stdout"].as<bool>(), prefix );           
+            outputWriters(pe, se, vm["fastq-output"].as<bool>(), vm["tab-output"].as<bool>(), vm["interleaved-output"].as<bool>(), vm["unmapped-output"].as<bool>(), vm["force"].as<bool>(), vm["gzip-output"].as<bool>(), vm["to-stdout"].as<bool>(), prefix );
 
             if(vm.count("read1-input")) {
                 if (!vm.count("read2-input")) {
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
                 }
                 auto read1_files = vm["read1-input"].as<std::vector<std::string> >();
                 auto read2_files = vm["read2-input"].as<std::vector<std::string> >();
-                
+
                 if (read1_files.size() != read2_files.size()) {
                     throw std::runtime_error("must have same number of input files for read1 and read2");
                 }
@@ -104,50 +104,61 @@ int main(int argc, char** argv)
                 for(size_t i = 0; i < read1_files.size(); ++i) {
                     bi::stream<bi::file_descriptor_source> is1{check_open_r(read1_files[i]), bi::close_handle};
                     bi::stream<bi::file_descriptor_source> is2{check_open_r(read2_files[i]), bi::close_handle};
-                   
+
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
                 }
-            }
-
-            if(vm.count("singleend-input")) {
+                if(vm.count("singleend-input")) { // can have paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
+                    }
+                }
+            } else if(vm.count("singleend-input")) {
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
                     helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
                 }
-            }
-            
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
                 }
-            }
-            
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) { // can have interleaved paired-end reads and/or single-end reads
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
                 }
-            }
-           
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) {
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
-                    helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
-            }  
+                helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["r1-cut-left"].as<size_t>(), vm["r1-cut-right"].as<size_t>(), vm["r2-cut-left"].as<size_t>(), vm["r2-cut-right"].as<size_t>(), vm["max-length"].as<size_t>() );
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              version_or_help(program_name, app_description, cmdline_options, vm, true);
+              exit(ERROR_IN_COMMAND_LINE); //success
+            }
             counters.write_out();
         }
         catch(po::error& e)
         {
             std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-            version_or_help(program_name, app_description, cmdline_options, vm, true);
             return ERROR_IN_COMMAND_LINE;
         }
 

--- a/hts_NTrimmer/src/hts_NTrimmer.cpp
+++ b/hts_NTrimmer/src/hts_NTrimmer.cpp
@@ -96,46 +96,57 @@ int main(int argc, char** argv)
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-
-            if(vm.count("singleend-input")) {
+                if(vm.count("singleend-input")) { // can have paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    }
+                }
+            } else if(vm.count("singleend-input")) {
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
                     helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) { // can have interleaved paired-end reads and/or single-end reads
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) {
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
                 helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              version_or_help(program_name, app_description, cmdline_options, vm, true);
+              exit(ERROR_IN_COMMAND_LINE); //success
             }
             counters.write_out();
         }
         catch(po::error& e)
         {
             std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-            version_or_help(program_name, app_description, cmdline_options, vm, true);
             return ERROR_IN_COMMAND_LINE;
         }
     }

--- a/hts_Overlapper/src/hts_Overlapper.cpp
+++ b/hts_Overlapper/src/hts_Overlapper.cpp
@@ -31,7 +31,7 @@ namespace bi = boost::iostreams;
 int main(int argc, char** argv)
 {
     const std::string program_name = "hts_Overlapper";
-    std::string app_description = 
+    std::string app_description =
                        "The hts_Overlapper application attempts to overlap paired end reads\n";
     app_description += "  to produce the original transcript, trim adapters, and in some\n";
     app_description += "  cases, correct sequencing errors.\n";
@@ -67,7 +67,7 @@ int main(int argc, char** argv)
         setDefaultParamsOverlapping(desc);
             // kmer|k ; kmer-offset|r ; max-mismatch-errorDensity|x
             // check-lengths|c ; min-overlap|o
-        
+
         po::options_description cmdline_options;
         cmdline_options.add(standard).add(input).add(output).add(desc);
 
@@ -76,17 +76,17 @@ int main(int argc, char** argv)
         {
             po::store(po::parse_command_line(argc, argv, cmdline_options),
                       vm); // can throw
-            
+
             version_or_help(program_name, app_description, cmdline_options, vm);
 
             po::notify(vm); // throws on error, so do after help in case
-         
+
             std::string statsFile(vm["stats-file"].as<std::string>());
             std::string prefix(vm["prefix"].as<std::string>());
-   
+
             std::shared_ptr<OutputWriter> pe = nullptr;
             std::shared_ptr<OutputWriter> se = nullptr;
-            
+
             OverlappingCounters counters(statsFile, vm["append-stats-file"].as<bool>(), program_name, vm["notes"].as<std::string>());
 
             outputWriters(pe, se, vm["fastq-output"].as<bool>(), vm["tab-output"].as<bool>(), vm["interleaved-output"].as<bool>(), vm["unmapped-output"].as<bool>(), vm["force"].as<bool>(), vm["gzip-output"].as<bool>(), vm["to-stdout"].as<bool>(), prefix );
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
                 }
                 auto read1_files = vm["read1-input"].as<std::vector<std::string> >();
                 auto read2_files = vm["read2-input"].as<std::vector<std::string> >();
-                
+
                 if (read1_files.size() != read2_files.size()) {
                     throw std::runtime_error("must have same number of input files for read1 and read2");
                 }
@@ -107,47 +107,59 @@ int main(int argc, char** argv)
                     bi::stream<bi::file_descriptor_source> is2{check_open_r(read2_files[i]), bi::close_handle};
 
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
-                    helper_overlapper(ifp, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() ); }
-            }
-
-            if(vm.count("singleend-input")) {
+                    helper_overlapper(ifp, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() );
+                }
+                if(vm.count("singleend-input")) { // can have interleaved paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_overlapper(ifs, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() );
+                    }
+                }
+            } else if(vm.count("singleend-input")) {
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
                     helper_overlapper(ifs, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-            
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     helper_overlapper(ift, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-            
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) { // can have interleaved paired-end reads and/or single-end reads
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     helper_overlapper(ifp, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-           
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) {
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_overlapper(ifs, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() );
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
                 helper_overlapper(ift, pe, se, counters, vm["max-mismatch-errorDensity"].as<double>(), vm["max-mismatch"].as<size_t>(), vm["min-overlap"].as<size_t>(), vm["stranded"].as<bool>(), vm["min-length"].as<size_t>(), vm["check-lengths"].as<size_t>(),   vm["kmer"].as<size_t>(), vm["kmer-offset"].as<size_t>(), vm["no-orphans"].as<bool>() );
-            }  
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              version_or_help(program_name, app_description, cmdline_options, vm, true);
+              exit(ERROR_IN_COMMAND_LINE); //success
+            }
             counters.write_out();
         }
         catch(po::error& e)
         {
             std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-            version_or_help(program_name, app_description, cmdline_options, vm, true);
             return ERROR_IN_COMMAND_LINE;
         }
 
@@ -163,4 +175,3 @@ int main(int argc, char** argv)
     return SUCCESS;
 
 }
-

--- a/hts_PolyATTrim/src/hts_PolyATTrim.cpp
+++ b/hts_PolyATTrim/src/hts_PolyATTrim.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv)
 {
 
     const std::string program_name = "hts_PolyATTrim";
-    std::string app_description = 
+    std::string app_description =
                        "hts_PolyATTrim trims poly A and T sequences from the 5' end of a read.\n";
     app_description += "  It start at the 5' end of a read and expands a window towards the 3' end \n";
     app_description += "  until the max-mismatch parameter is met. If the window is at least\n";
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
 
         setDefaultParamsCutting(desc);
             // no-orphans|n ; stranded|s ; min-length|m
-        setDefaultParamsTrim(desc); 
+        setDefaultParamsTrim(desc);
             // no-left|l ; no-right|r
 
         desc.add_options()
@@ -72,11 +72,11 @@ int main(int argc, char** argv)
                       vm); // can throw
 
             version_or_help( program_name, app_description, cmdline_options, vm);
-            
+
             /** --help option
              */
             po::notify(vm); // throws on error, so do after help in case
-            
+
 
             std::string statsFile(vm["stats-file"].as<std::string>());
             std::string prefix(vm["prefix"].as<std::string>());
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
                 }
                 auto read1_files = vm["read1-input"].as<std::vector<std::string> >();
                 auto read2_files = vm["read2-input"].as<std::vector<std::string> >();
-                
+
                 if (read1_files.size() != read2_files.size()) {
                     throw std::runtime_error("must have same number of input files for read1 and read2");
                 }
@@ -102,50 +102,61 @@ int main(int argc, char** argv)
                 for(size_t i = 0; i < read1_files.size(); ++i) {
                     bi::stream<bi::file_descriptor_source> is1{check_open_r(read1_files[i]), bi::close_handle};
                     bi::stream<bi::file_descriptor_source> is2{check_open_r(read2_files[i]), bi::close_handle};
-                   
+
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<std::size_t>(), vm["min-trim"].as<std::size_t>(), vm["max-mismatch"].as<std::size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-
-            if(vm.count("singleend-input")) {
+                if(vm.count("singleend-input")) { // can have paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<std::size_t>(), vm["min-trim"].as<std::size_t>(), vm["max-mismatch"].as<std::size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    }
+                }
+            } else if(vm.count("singleend-input")) {
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
                     helper_trim(ifs, pe, se, counters, vm["min-length"].as<std::size_t>(), vm["min-trim"].as<std::size_t>(), vm["max-mismatch"].as<std::size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-            
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     helper_trim(ift, pe, se, counters, vm["min-length"].as<std::size_t>(), vm["min-trim"].as<std::size_t>(), vm["max-mismatch"].as<std::size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-            
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) { // can have interleaved paired-end reads and/or single-end reads
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<std::size_t>(), vm["min-trim"].as<std::size_t>(), vm["max-mismatch"].as<std::size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
                 }
-            }
-           
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) {
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<std::size_t>(), vm["min-trim"].as<std::size_t>(), vm["max-mismatch"].as<std::size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
                 helper_trim(ift, pe, se, counters, vm["min-length"].as<std::size_t>(), vm["min-trim"].as<std::size_t>(), vm["max-mismatch"].as<std::size_t>(), vm["stranded"].as<bool>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>(), vm["no-orphans"].as<bool>() );
-            }  
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              version_or_help(program_name, app_description, cmdline_options, vm, true);
+              exit(ERROR_IN_COMMAND_LINE); //success
+            }
             counters.write_out();
         }
         catch(po::error& e)
         {
             std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-            version_or_help(program_name, app_description, cmdline_options, vm, true);
             return ERROR_IN_COMMAND_LINE;
         }
 

--- a/hts_QWindowTrim/src/hts_QWindowTrim.cpp
+++ b/hts_QWindowTrim/src/hts_QWindowTrim.cpp
@@ -109,46 +109,57 @@ int main(int argc, char** argv)
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
-            }
-
-            if(vm.count("singleend-input")) {
+                if(vm.count("singleend-input")) { // can have paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
+                    }
+                }
+            } else if(vm.count("singleend-input")) {
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
                     helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
-            }
-
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
-            }
-
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) { // can have interleaved paired-end reads and/or single-end reads
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
                 }
-            }
-
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) {
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
                 helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), qual_threshold, vm["window-size"].as<size_t>(), vm["no-left"].as<bool>(), vm["no-right"].as<bool>() );
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              version_or_help(program_name, app_description, cmdline_options, vm, true);
+              exit(ERROR_IN_COMMAND_LINE); //success
             }
             counters.write_out();
         }
         catch(po::error& e)
         {
             std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-            version_or_help(program_name, app_description, cmdline_options, vm, true);
             return ERROR_IN_COMMAND_LINE;
         }
 

--- a/hts_SeqScreener/src/hts_SeqScreener.cpp
+++ b/hts_SeqScreener/src/hts_SeqScreener.cpp
@@ -129,46 +129,57 @@ int main(int argc, char** argv)
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
                     helper_discard(ifp, pe, se, counters, lookup, vm["percentage-hits"].as<double>(), vm["check-read-2"].as<bool>(),vm["kmer"].as<size_t>(), vm["inverse"].as<bool>(), vm["record"].as<bool>());
                 }
-            }
-
-            if(vm.count("singleend-input")) {
+                if(vm.count("singleend-input")) { // can have paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_discard(ifs, pe, se, counters, lookup, vm["percentage-hits"].as<double>(), vm["check-read-2"].as<bool>(),vm["kmer"].as<size_t>(), vm["inverse"].as<bool>(), vm["record"].as<bool>());
+                    }
+                }
+            } else if(vm.count("singleend-input")) { // can also just have single-end reads
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
                     helper_discard(ifs, pe, se, counters, lookup, vm["percentage-hits"].as<double>(), vm["check-read-2"].as<bool>(),vm["kmer"].as<size_t>(), vm["inverse"].as<bool>(), vm["record"].as<bool>());
                 }
-            }
-
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     helper_discard(ift, pe, se, counters, lookup, vm["percentage-hits"].as<double>(), vm["check-read-2"].as<bool>(),vm["kmer"].as<size_t>(), vm["inverse"].as<bool>(), vm["record"].as<bool>());
                 }
-            }
-
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) {
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     helper_discard(ifp, pe, se, counters, lookup, vm["percentage-hits"].as<double>(), vm["check-read-2"].as<bool>(),vm["kmer"].as<size_t>(), vm["inverse"].as<bool>(), vm["record"].as<bool>());
                 }
-            }
-
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) { // can have interleaved paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_discard(ifs, pe, se, counters, lookup, vm["percentage-hits"].as<double>(), vm["check-read-2"].as<bool>(),vm["kmer"].as<size_t>(), vm["inverse"].as<bool>(), vm["record"].as<bool>());
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
                 helper_discard(ift, pe, se, counters, lookup, vm["percentage-hits"].as<double>(), vm["check-read-2"].as<bool>(),vm["kmer"].as<size_t>(), vm["inverse"].as<bool>(), vm["record"].as<bool>());
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              version_or_help(program_name, app_description, cmdline_options, vm, true);
+              exit(ERROR_IN_COMMAND_LINE); //success
             }
             counters.write_out();
         }
         catch(po::error& e)
         {
             std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-            version_or_help(program_name, app_description, cmdline_options, vm, true);
             return ERROR_IN_COMMAND_LINE;
         }
 

--- a/hts_SeqScreener/src/hts_SeqScreener.h
+++ b/hts_SeqScreener/src/hts_SeqScreener.h
@@ -300,7 +300,7 @@ void setLookup( kmerSet &lookup, Read &rb, size_t kmerSize) {
     std::string seq = rb.get_seq();
     std::pair<bool, bool> bits;
     for (std::string::iterator bp = seq.begin(); bp != seq.end(); ++bp) {
-        if (std::toupper(*bp) == 'A' || std::toupper(*bp) == 'C' || std::toupper(*bp) == 'G' || std::toupper(*bp) == 'T' ) { // N
+        if (std::toupper(*bp) == 'A' || std::toupper(*bp) == 'C' || std::toupper(*bp) == 'G' || std::toupper(*bp) == 'T' ) {
             reverseLookup >>= 2;
             forwardLookup <<=2;
 
@@ -314,7 +314,7 @@ void setLookup( kmerSet &lookup, Read &rb, size_t kmerSize) {
                 boost::dynamic_bitset<> &bs = forwardLookup > reverseLookup ? forwardLookup : reverseLookup;
                 lookup.insert(bs);
             }
-         } else {
+         } else { // all other characters (N, ambiguities) produce no kmers
            current_added = 0;
          }
     }

--- a/hts_Stats/src/hts_Stats.cpp
+++ b/hts_Stats/src/hts_Stats.cpp
@@ -32,7 +32,7 @@ namespace bi = boost::iostreams;
 int main(int argc, char** argv)
 {
     const std::string program_name = "hts_Stats";
-    std::string app_description = 
+    std::string app_description =
                        "The hts_Stats app produce basic statistics about the reads in a dataset.\n";
     app_description += "  Including the basepair composition and number of bases Q30.";
 
@@ -63,18 +63,18 @@ int main(int argc, char** argv)
             /** --help option
              */
             version_or_help(program_name, app_description, cmdline_options, vm);
-            
+
             po::notify(vm); // throws on error, so do after help in case
 
             std::string statsFile(vm["stats-file"].as<std::string>());
             std::string prefix(vm["prefix"].as<std::string>());
-            
+
             std::shared_ptr<OutputWriter> pe = nullptr;
             std::shared_ptr<OutputWriter> se = nullptr;
-            
+
             StatsCounters counters(statsFile, vm["append-stats-file"].as<bool>() , program_name, vm["notes"].as<std::string>());
 
-            outputWriters(pe, se, vm["fastq-output"].as<bool>(), vm["tab-output"].as<bool>(), vm["interleaved-output"].as<bool>(), vm["unmapped-output"].as<bool>(), vm["force"].as<bool>(), vm["gzip-output"].as<bool>(), vm["to-stdout"].as<bool>(), prefix );           
+            outputWriters(pe, se, vm["fastq-output"].as<bool>(), vm["tab-output"].as<bool>(), vm["interleaved-output"].as<bool>(), vm["unmapped-output"].as<bool>(), vm["force"].as<bool>(), vm["gzip-output"].as<bool>(), vm["to-stdout"].as<bool>(), prefix );
 
             if(vm.count("read1-input")) {
                 if (!vm.count("read2-input")) {
@@ -82,52 +82,61 @@ int main(int argc, char** argv)
                 }
                 auto read1_files = vm["read1-input"].as<std::vector<std::string> >();
                 auto read2_files = vm["read2-input"].as<std::vector<std::string> >();
-                
+
                 if (read1_files.size() != read2_files.size()) {
                     throw std::runtime_error("must have same number of input files for read1 and read2");
                 }
-
                 for(size_t i = 0; i < read1_files.size(); ++i) {
                     bi::stream<bi::file_descriptor_source> is1{check_open_r(read1_files[i]), bi::close_handle};
                     bi::stream<bi::file_descriptor_source> is2{check_open_r(read2_files[i]), bi::close_handle};
-                   
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
                     helper_stats(ifp, pe, se, counters);
                 }
-            }
-
-            if(vm.count("singleend-input")) {
+                if(vm.count("singleend-input")) { // can have paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_stats(ifs, pe, se,counters);
+                    }
+                }
+            } else if(vm.count("singleend-input")) {
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
                     helper_stats(ifs, pe, se,counters);
                 }
-            }
-            
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     helper_stats(ift, pe, se,counters);
                 }
-            }
-            
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) { // can have interleaved paired-end reads and/or single-end reads
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     helper_stats(ifp, pe, se,counters);
                 }
-            }
-           
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) {
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
+                        helper_stats(ifs, pe, se,counters);
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
                 helper_stats(ift, pe, se,counters);
-            }  
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              exit(ERROR_IN_COMMAND_LINE); //success
+            }
             counters.write_out();
         }
         catch(po::error& e)

--- a/hts_SuperDeduper/src/hts_SuperDeduper.cpp
+++ b/hts_SuperDeduper/src/hts_SuperDeduper.cpp
@@ -104,39 +104,51 @@ int main(int argc, char** argv)
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
                     load_map(ifp, counters, read_map, pe, se,vm["avg-qual-score"].as<double>(), vm["inform-avg-qual-score"].as<double>(), vm["start"].as<size_t>() - 1, vm["length"].as<size_t>(), vm["log_freq"].as<size_t>() );
                 }
-            }
-
-            if(vm.count("singleend-input")) {
+                if(vm.count("singleend-input")) { // can have paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> ser{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(ser);
+                        load_map(ifs, counters, read_map, pe, se,vm["avg-qual-score"].as<double>(), vm["inform-avg-qual-score"].as<double>(), vm["start"].as<size_t>() - 1, vm["length"].as<size_t>(), vm["log_freq"].as<size_t>() );
+                    }
+                }
+            } else if(vm.count("singleend-input")) {
                 auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> ser{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(ser);
                     load_map(ifs, counters, read_map, pe, se,vm["avg-qual-score"].as<double>(), vm["inform-avg-qual-score"].as<double>(), vm["start"].as<size_t>() - 1, vm["length"].as<size_t>(), vm["log_freq"].as<size_t>() );
                 }
-            }
-
-            if(vm.count("tab-input")) {
+            } else if(vm.count("tab-input")) {
                 auto read_files = vm["tab-input"].as<std::vector<std::string> > ();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
                     load_map(ift, counters, read_map, pe, se,vm["avg-qual-score"].as<double>(),  vm["inform-avg-qual-score"].as<double>(),  vm["start"].as<size_t>() - 1, vm["length"].as<size_t>(), vm["log_freq"].as<size_t>() );
                 }
-            }
-
-            if (vm.count("interleaved-input")) {
+            } else if (vm.count("interleaved-input")) {
                 auto read_files = vm["interleaved-input"].as<std::vector<std::string > >();
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifp(inter);
                     load_map(ifp, counters, read_map, pe, se,vm["avg-qual-score"].as<double>(),  vm["inform-avg-qual-score"].as<double>(), vm["start"].as<size_t>() - 1, vm["length"].as<size_t>(), vm["log_freq"].as<size_t>() );
                 }
-            }
-
-            if (vm.count("from-stdin")) {
+                if(vm.count("singleend-input")) { // can have interleaved paired-end reads and/or single-end reads
+                    auto read_files = vm["singleend-input"].as<std::vector<std::string> >();
+                    for (auto file : read_files) {
+                        bi::stream<bi::file_descriptor_source> ser{ check_open_r(file), bi::close_handle};
+                        InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(ser);
+                        load_map(ifs, counters, read_map, pe, se,vm["avg-qual-score"].as<double>(), vm["inform-avg-qual-score"].as<double>(), vm["start"].as<size_t>() - 1, vm["length"].as<size_t>(), vm["log_freq"].as<size_t>() );
+                    }
+                }
+            } else if (vm.count("from-stdin")) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
                 load_map(ift, counters, read_map, pe, se,vm["avg-qual-score"].as<double>(),  vm["inform-avg-qual-score"].as<double>(),  vm["start"].as<size_t>() - 1, vm["length"].as<size_t>(), vm["log_freq"].as<size_t>() );
+            } else {
+              std::cerr << "ERROR: " << "Input file type absent from command line" << std::endl << std::endl;
+              version_or_help(program_name, app_description, cmdline_options, vm, true);
+              exit(ERROR_IN_COMMAND_LINE); //success
             }
 
             for(auto const &i : read_map) {


### PR DESCRIPTION
This pull request, does a couple of things, all of which are cosmetic and none should change any read processing behavior
1) deals with issues #101 and #125, 
    for #101 it fixes the sam flag values to correct values, see issue comment
    for #125 changes code to require an output format be specified and adds in error when not. I agree with this request as streaming is so integral to HTStream we want people to explicitly define output type and not have a default.

2) Also fixes some of the output read filenames to a consistent format (plus a spelling error was present)

3) Changes input to allow only one input type, prior code in theory allowed for specification of fastq, interleaved, se/pe, tab and stdin all at the same time. I can't see that ever happening and not sure we'd want it either. So restricted input type to just one type: PE fastq (paired or interleaved) with or without SE, SE fastq only, tab only, OR stdin. Errors when not one of those.