### PR TITLE
making binaries completely static for redistribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,12 @@ cmake_minimum_required (VERSION 2.8)
 project (HTStream)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
-set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+#set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 set(BUILD_SHARED_LIBS OFF)
 set(Boost_USE_STATIC_LIBS   ON)
+if (UNIX)
+  set(EXTRA_BUILD_FLAGS "-static")
+endif()
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required (VERSION 2.8)
 project (HTStream)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(BUILD_SHARED_LIBS OFF)
+set(Boost_USE_STATIC_LIBS   ON)
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
 #set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 set(BUILD_SHARED_LIBS OFF)
 set(Boost_USE_STATIC_LIBS   ON)
-if (UNIX)
+
+if (APPLE)
+elseif (UNIX)
   set(EXTRA_BUILD_FLAGS "-static")
 endif()
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -22,9 +22,7 @@ file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/test/*.cpp)
 link_directories(${GTEST_LIBS_DIR})
 
 add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES} ${sources})
-set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
-set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
 
 #add_dependencies(${PROJECT_TEST_NAME} googletest)
-target_link_libraries(${PROJECT_TEST_NAME} -static gtest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${PROJECT_LINK_LIBS})
+target_link_libraries(${PROJECT_TEST_NAME} gtest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${PROJECT_LINK_LIBS})
 add_test(test_common ${PROJECT_TEST_NAME})

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -22,6 +22,9 @@ file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/test/*.cpp)
 link_directories(${GTEST_LIBS_DIR})
 
 add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES} ${sources})
+set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+
 #add_dependencies(${PROJECT_TEST_NAME} googletest)
-target_link_libraries(${PROJECT_TEST_NAME} gtest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${PROJECT_LINK_LIBS})
+target_link_libraries(${PROJECT_TEST_NAME} -static gtest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${PROJECT_LINK_LIBS})
 add_test(test_common ${PROJECT_TEST_NAME})

--- a/hts_AdapterTrimmer/CMakeLists.txt
+++ b/hts_AdapterTrimmer/CMakeLists.txt
@@ -37,12 +37,8 @@ include_directories(${GTEST_INCLUDE_DIRS} ${Boost_INCLUDE_DIR}
 file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/test/*.cpp)
 link_directories(${GTEST_LIBS_DIR})
 list(REMOVE_ITEM sources ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}.cpp)
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dprivate=public -lboost_serialization -lboost_unit_test_framework-mt -lboost_program_options")
 
 add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES} ${sources})
-set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
-set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
 
-#add_dependencies(${PROJECT_TEST_NAME} googletest)
 target_link_libraries(${PROJECT_TEST_NAME} gtest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${PROJECT_LINK_LIBS})
 add_test(${PROJECT_TEST_NAME} ${PROJECT_TEST_NAME})

--- a/hts_AdapterTrimmer/CMakeLists.txt
+++ b/hts_AdapterTrimmer/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_AdapterTrimmer/CMakeLists.txt
+++ b/hts_AdapterTrimmer/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}
@@ -38,6 +40,9 @@ list(REMOVE_ITEM sources ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}.cpp)
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dprivate=public -lboost_serialization -lboost_unit_test_framework-mt -lboost_program_options")
 
 add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES} ${sources})
+set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_TEST_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+
 #add_dependencies(${PROJECT_TEST_NAME} googletest)
 target_link_libraries(${PROJECT_TEST_NAME} gtest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${PROJECT_LINK_LIBS})
 add_test(${PROJECT_TEST_NAME} ${PROJECT_TEST_NAME})

--- a/hts_CutTrim/CMakeLists.txt
+++ b/hts_CutTrim/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_cut_trim
   DEPENDS ${PROJECT_NAME}

--- a/hts_CutTrim/CMakeLists.txt
+++ b/hts_CutTrim/CMakeLists.txt
@@ -16,7 +16,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_cut_trim
   DEPENDS ${PROJECT_NAME}

--- a/hts_NTrimmer/CMakeLists.txt
+++ b/hts_NTrimmer/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_N_Remover
   DEPENDS ${PROJECT_NAME}

--- a/hts_NTrimmer/CMakeLists.txt
+++ b/hts_NTrimmer/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_N_Remover
   DEPENDS ${PROJECT_NAME}

--- a/hts_Overlapper/CMakeLists.txt
+++ b/hts_Overlapper/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_Overlapper/CMakeLists.txt
+++ b/hts_Overlapper/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_PolyATTrim/CMakeLists.txt
+++ b/hts_PolyATTrim/CMakeLists.txt
@@ -16,7 +16,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_PolyATTrim/CMakeLists.txt
+++ b/hts_PolyATTrim/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_QWindowTrim/CMakeLists.txt
+++ b/hts_QWindowTrim/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_QWindowTrim/CMakeLists.txt
+++ b/hts_QWindowTrim/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_SeqScreener/CMakeLists.txt
+++ b/hts_SeqScreener/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_SeqScreener/CMakeLists.txt
+++ b/hts_SeqScreener/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_Stats/CMakeLists.txt
+++ b/hts_Stats/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_Stats/CMakeLists.txt
+++ b/hts_Stats/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(valgrind_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_SuperDeduper/CMakeLists.txt
+++ b/hts_SuperDeduper/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(${PROJECT_NAME} ${sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
 
-target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${EXTRA_BUILD_FLAGS} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(hts_pytest_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}

--- a/hts_SuperDeduper/CMakeLists.txt
+++ b/hts_SuperDeduper/CMakeLists.txt
@@ -16,7 +16,10 @@ include_directories(${COMMON_INCLUDES} ${Boost_INCLUDE_DIR} )
 
 
 add_executable(${PROJECT_NAME} ${sources})
-target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+
+target_link_libraries(${PROJECT_NAME} -static ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES})
 
 add_custom_target(hts_pytest_${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME}
@@ -40,9 +43,8 @@ include_directories(${GTEST_INCLUDE_DIRS} ${Boost_INCLUDE_DIR} ${COMMON_INCLUDES
 file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/test/*.cpp)
 link_directories(${GTEST_LIBS_DIR})
 list(REMOVE_ITEM sources ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}.cpp)
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dprivate=public -lboost_serialization -lboost_unit_test_framework-mt -lboost_program_options")
 
 add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES} ${sources})
-#add_dependencies(${PROJECT_TEST_NAME} googletest)
+
 target_link_libraries(${PROJECT_TEST_NAME} gtest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${PROJECT_LINK_LIBS})
 add_test(${PROJECT_TEST_NAME} ${PROJECT_TEST_NAME})


### PR DESCRIPTION
Note that test libs cannot be static due to use boost tests use of getaddrinfo, see https://stackoverflow.com/questions/2725255/create-statically-linked-binary-that-uses-getaddrinfo