### PR TITLE
making static bin optional, defaults to off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 2.8)
 project (HTStream)
 
+option(BUILD_STATIC_BIN "builds static binary (linux only)" OFF)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
 #set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 set(BUILD_SHARED_LIBS OFF)
@@ -8,7 +10,9 @@ set(Boost_USE_STATIC_LIBS   ON)
 
 if (APPLE)
 elseif (UNIX)
-  set(EXTRA_BUILD_FLAGS "-static")
+  if (BUILD_STATIC_BIN)
+    set(EXTRA_BUILD_FLAGS "-static")
+  endif()
 endif()
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")


### PR DESCRIPTION
To configure static build:

```
cmake .. -DBUILD_STATIC_BIN=ON
```