### PR TITLE
Update SeqScreen so that fasta files are not concatenated (which crea…

### DIFF
--- a/hts_SeqScreener/src/hts_SeqScreener.cpp
+++ b/hts_SeqScreener/src/hts_SeqScreener.cpp
@@ -91,25 +91,27 @@ int main(int argc, char** argv)
 
             //sets read information
             //Phix isn't set to default since it makes help a PITA to read
-            Read readSeq;
+            //sets kmer lookup arrays
+            kmerSet lookup;
+            uint64_t screen_len;
             std::string lookup_file = vm["seq"].as<std::string>();
             if (vm["seq"].as<std::string>() != "") {
                 bi::stream <bi::file_descriptor_source> fa{check_open_r(lookup_file), bi::close_handle};
                 InputReader<SingleEndRead, FastaReadImpl> faReader(fa);
-                readSeq = fasta_set_to_one_read(faReader);
+                screen_len = setLookup_fasta(lookup, faReader, vm["kmer"].as<size_t>());
             } else {
-                readSeq = Read(phixSeq_True, "", "");
+                Read readSeq;
                 lookup_file = "PhiX";
+                readSeq = Read(phixSeq_True, "", "");
+                screen_len = readSeq.getLength();
+                setLookup_read(lookup, readSeq, vm["kmer"].as<size_t>());
             }
-            //sets kmer lookup arrays
-            kmerSet lookup;
-            setLookup(lookup, readSeq, vm["kmer"].as<size_t>());
             if (lookup.size() == 0){
                 std::cerr << "\n\tException lookup table contains no kmers" << std::endl;
                 return ERROR_NOLOOKUP_EXCEPTION;
             }
 
-            counters.set_screeninfo(lookup_file, readSeq.getLength(), lookup.size());
+            counters.set_screeninfo(lookup_file, screen_len, lookup.size());
 
             if(vm.count("read1-input")) {
                 if (!vm.count("read2-input")) {

--- a/hts_SeqScreener/src/hts_SeqScreener.h
+++ b/hts_SeqScreener/src/hts_SeqScreener.h
@@ -98,17 +98,6 @@ void setBitsBools(boost::dynamic_bitset<> &bs, size_t loc, bool set1, bool set2)
     bs[loc + 1] = set2;
 }
 
-Read fasta_set_to_one_read(InputReader<SingleEndRead, FastaReadImpl> &faReader     ) {
-    std::string s;
-
-    while(faReader.has_next()) {
-        auto r = faReader.next();
-        s += (r->get_read().get_seq());
-    }
-    return Read(s, "", "All_Header");
-}
-
-
 std::pair <bool, bool> setBitsChar(char c) {
 
     switch (std::toupper(c)) {
@@ -284,7 +273,7 @@ void helper_discard(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> 
     /*These the lookups are compared, the larger Lookup is taken and searched for,
      * if there is a "soft hit", initiate a search of the vector with the cooresponding Rest*/
 
-void setLookup( kmerSet &lookup, Read &rb, size_t kmerSize) {
+void setLookup_read( kmerSet &lookup, Read &rb, size_t kmerSize) {
     /*This function is only called once, these values calculation are minimal cost so they are not in the function args*/
     /*Total size of kmer bits*/
     size_t bitKmer = kmerSize * 2;
@@ -319,6 +308,17 @@ void setLookup( kmerSet &lookup, Read &rb, size_t kmerSize) {
          }
     }
 
+}
+
+uint64_t setLookup_fasta( kmerSet &lookup, InputReader<SingleEndRead, FastaReadImpl> &faReader, size_t kmerSize ) {
+    uint64_t slen = 0;
+    while(faReader.has_next()) {
+        auto r = faReader.next();
+        Read readSeq = Read(r->get_read().get_seq(), "", "");
+        slen += readSeq.getLength();
+        setLookup_read(lookup, readSeq, kmerSize);
+    }
+    return slen;
 }
 
 #endif

--- a/hts_SeqScreener/test/hts_TestSeqScreener.cpp
+++ b/hts_SeqScreener/test/hts_TestSeqScreener.cpp
@@ -10,14 +10,21 @@ class SeqScreener : public ::testing::Test {
         const size_t lookup_kmer_test = 2;
 };
 
-TEST_F(SeqScreener, all_from_fastq) {
-    const std::string faFile = ">1\nACGT\nACGT\n>2\nTTTT\n";
-    std::istringstream fa(faFile);
-    InputReader<SingleEndRead, FastaReadImpl> f(fa);
-    Read r = fasta_set_to_one_read( f );
-    std::cout << r.get_seq() << '\n';
-    ASSERT_EQ("ACGTACGTTTTT", r.get_seq());
-};
+TEST_F(SeqScreener, check_fasta) {
+  const std::string faFile = ">1\nAGCTAGCT\n>2\nCCGGAATTCC\n";
+  std::istringstream fa(faFile);
+  InputReader<SingleEndRead, FastaReadImpl> f(fa);
+
+  kmerSet lookup;
+  uint64_t screen_len;
+  size_t true_kmer = 5;
+  screen_len = setLookup_fasta(lookup, f, true_kmer);
+
+  std::cout << "Length should be 18 == " << screen_len << '\n';
+  ASSERT_EQ(18, screen_len);
+  std::cout << "Lookup size should be 6 == " << lookup.size() << '\n';
+  ASSERT_EQ(6,lookup.size());
+}
 
 TEST_F(SeqScreener, check_check_read) {
     std::string s("AAAAAAAGCT");
@@ -25,7 +32,7 @@ TEST_F(SeqScreener, check_check_read) {
     Read testRead = Read(s, "", "");
     kmerSet lookup;
     size_t true_kmer = 5;
-    setLookup(lookup, readPhix, true_kmer);
+    setLookup_read(lookup, readPhix, true_kmer);
 
     boost::dynamic_bitset<> fLu(true_kmer * 2);
     boost::dynamic_bitset<> rLu(true_kmer * 2);
@@ -43,7 +50,7 @@ TEST_F(SeqScreener, setLookupTestOrderedVec) {
     Read readPhix = Read(s, "", "");
     kmerSet lookup;
 
-    setLookup(lookup, readPhix, 5);
+    setLookup_read(lookup, readPhix, 5);
     std::cout << lookup.size() << '\n';
     ASSERT_EQ(4, lookup.size());
 };
@@ -53,7 +60,7 @@ TEST_F(SeqScreener, setLookupTest) {
     std::cout << "Testing Building Lookup Table with sequence " << s << '\n';
     Read readPhix = Read(s, "", "");
     kmerSet lookup;
-    setLookup(lookup, readPhix, 5);
+    setLookup_read(lookup, readPhix, 5);
     //ASSERT_EQ(true , lookup.end != lookup.find(boost::dynamic_bitset<>(10, "1001111111")))
     //std::string s("1001111111");
 
@@ -65,7 +72,7 @@ TEST_F(SeqScreener, setLookupTestAmbiguities) {
     Read readAmbiguities = Read(s, "", "");
     std::cout << "Seq in read " << readAmbiguities.get_seq() << '\n';
     kmerSet lookup;
-    setLookup(lookup, readAmbiguities, 5);
+    setLookup_read(lookup, readAmbiguities, 5);
     std::cout << "myset contains:";
     for ( auto it = lookup.begin(); it != lookup.end(); ++it )
         std::cout << " " << *it;
@@ -80,7 +87,7 @@ TEST_F(SeqScreener, setLookupTestAmbiguities2_nokmers) {
     Read readAmbiguities = Read(s, "", "");
     std::cout << "Seq in read " << readAmbiguities.get_seq() << '\n';
     kmerSet lookup;
-    setLookup(lookup, readAmbiguities, 5);
+    setLookup_read(lookup, readAmbiguities, 5);
     std::cout << lookup.size() << '\n';
     ASSERT_EQ(0, lookup.size());
 };


### PR DESCRIPTION
Update SeqScreen so that fasta files are not concatenated (which creates bogus kmers) but rather processes each sequence in a fasta 1 at a time adding new kmers as one goes