### PR TITLE
N exclude

### DIFF
--- a/hts_NTrimmer/src/hts_NTrimmer.cpp
+++ b/hts_NTrimmer/src/hts_NTrimmer.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
             // no-orphans|n ; stranded|s ; min-length|m
 
         desc.add_options()
-            ("exlude,e", po::bool_switch()->default_value(false), "Exclude any sequence with an N character");
+            ("exclude,e", po::bool_switch()->default_value(false), "Exclude any sequence with an N character");
 
         po::options_description cmdline_options;
         cmdline_options.add(standard).add(input).add(output).add(desc);

--- a/hts_NTrimmer/src/hts_NTrimmer.cpp
+++ b/hts_NTrimmer/src/hts_NTrimmer.cpp
@@ -55,6 +55,9 @@ int main(int argc, char** argv)
         setDefaultParamsCutting(desc);
             // no-orphans|n ; stranded|s ; min-length|m
 
+        desc.add_options()
+            ("exlude,e", po::bool_switch()->default_value(false), "Exclude any sequence with an N character");
+
         po::options_description cmdline_options;
         cmdline_options.add(standard).add(input).add(output).add(desc);
 
@@ -88,7 +91,7 @@ int main(int argc, char** argv)
                     bi::stream<bi::file_descriptor_source> is1{check_open_r(read1_files[i]), bi::close_handle};
                     bi::stream<bi::file_descriptor_source> is2{check_open_r(read2_files[i]), bi::close_handle};
                     InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(is1, is2);
-                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ifp, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["exclude"].as<bool>() );
                 }
             }
             if (vm.count("interleaved-input")) {
@@ -96,7 +99,7 @@ int main(int argc, char** argv)
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> inter{ check_open_r(file), bi::close_handle};
                     InputReader<PairedEndRead, InterReadImpl> ifi(inter);
-                    helper_trim(ifi, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ifi, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["exclude"].as<bool>() );
                 }
             }
             if(vm.count("singleend-input")) {
@@ -104,7 +107,7 @@ int main(int argc, char** argv)
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> sef{ check_open_r(file), bi::close_handle};
                     InputReader<SingleEndRead, SingleEndReadFastqImpl> ifs(sef);
-                    helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ifs, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["exclude"].as<bool>() );
                 }
             }
             if(vm.count("tab-input")) {
@@ -112,13 +115,13 @@ int main(int argc, char** argv)
                 for (auto file : read_files) {
                     bi::stream<bi::file_descriptor_source> tabin{ check_open_r(file), bi::close_handle};
                     InputReader<ReadBase, TabReadImpl> ift(tabin);
-                    helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+                    helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["exclude"].as<bool>() );
                 }
             }
             if (!isatty(fileno(stdin))) {
                 bi::stream<bi::file_descriptor_source> tabin {fileno(stdin), bi::close_handle};
                 InputReader<ReadBase, TabReadImpl> ift(tabin);
-                helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>() );
+                helper_trim(ift, pe, se, counters, vm["min-length"].as<size_t>() , vm["stranded"].as<bool>(), vm["no-orphans"].as<bool>(), vm["exclude"].as<bool>() );
             }
             counters.write_out();
         }

--- a/hts_NTrimmer/src/hts_NTrimmer.h
+++ b/hts_NTrimmer/src/hts_NTrimmer.h
@@ -34,7 +34,7 @@ void trim_n(Read &rb, bool exclude) {
         i = static_cast<size_t>(it - seq.begin() );
 
         if (*it == 'N') {
-            if (exlude) {
+            if (exclude) {
               rb.setLCut(1);
               rb.setRCut(0);
               break;
@@ -69,7 +69,7 @@ void helper_trim(InputReader<T, Impl> &reader, std::shared_ptr<OutputWriter> pe,
             SingleEndRead* ser = dynamic_cast<SingleEndRead*>(i.get());
             if (ser) {
                 counters.input(*ser);
-                trim_n(ser->non_const_read_one());
+                trim_n(ser->non_const_read_one(), exclude);
                 ser->checkDiscarded(min_length);
                 writer_helper(ser, pe, se, false, false);
                 counters.output(*ser);

--- a/hts_NTrimmer/src/hts_NTrimmer.h
+++ b/hts_NTrimmer/src/hts_NTrimmer.h
@@ -37,7 +37,7 @@ void trim_n(Read &rb, bool exclude) {
             if (exclude) {
               rb.setLCut(1);
               rb.setRCut(0);
-              break;
+              return;
             } else {
                 currentLeft = i + 1;
             }

--- a/hts_NTrimmer/test/hts_TestNTrimmer.cpp
+++ b/hts_NTrimmer/test/hts_TestNTrimmer.cpp
@@ -17,6 +17,20 @@ class TrimN : public ::testing::Test {
         const std::string readData_9b = "@Read1\nCTGACTGACTGANNNACTGACTGACTGANTGACTG\n+\n###################################\n";
 };
 
+TEST_F(TrimN, Exclude) {
+    std::istringstream in1(readData_1);
+    std::istringstream in2(readData_5);
+
+    InputReader<PairedEndRead, PairedEndReadFastqImpl> ifp(in1, in2);
+
+    while(ifp.has_next()) {
+        auto i = ifp.next();
+        PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
+        trim_n(per->non_const_read_one(), true);
+        ASSERT_EQ("", (per->non_const_read_one()).get_sub_seq());
+    }
+};
+
 TEST_F(TrimN, EdgeRightN) {
     std::istringstream in1(readData_5);
     std::istringstream in2(readData_5);
@@ -26,7 +40,7 @@ TEST_F(TrimN, EdgeRightN) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
+        trim_n(per->non_const_read_one(), false);
         ASSERT_EQ("ATTTTAGGATTTTTTTTTTTTT", (per->non_const_read_one()).get_sub_seq());
     }
 };
@@ -41,7 +55,7 @@ TEST_F(TrimN, EdgeLeftN) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
+        trim_n(per->non_const_read_one(), false);
         ASSERT_EQ("TTTTAGGATTTTTTTTTTTTTA", (per->non_const_read_one()).get_sub_seq());
     }
 };
@@ -56,7 +70,7 @@ TEST_F(TrimN, EdgeCaseNonEnds) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
+        trim_n(per->non_const_read_one(), false);
         ASSERT_EQ("TTTTAGGATTTTTTTTTTTTT", (per->non_const_read_one()).get_sub_seq());
     }
 };
@@ -70,7 +84,7 @@ TEST_F(TrimN, BasicTrim) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
+        trim_n(per->non_const_read_one(), false);
         ASSERT_EQ("GAAAAAAAAAG", (per->non_const_read_one()).get_sub_seq());
     }
 };
@@ -84,7 +98,7 @@ TEST_F(TrimN, NoTrim) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
-        trim_n(per->non_const_read_two());
+        trim_n(per->non_const_read_two(), false);
         ASSERT_EQ("AAAAAAAAAAAAAAAAAAAAAAAA", (per->non_const_read_two()).get_sub_seq());
     }
 };
@@ -98,7 +112,7 @@ TEST_F(TrimN, TwoBasicTrim) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
+        trim_n(per->non_const_read_one(), false);
         ASSERT_EQ("TTTTTTTTTTTTT", (per->non_const_read_one()).get_sub_seq());
     }
 };
@@ -111,7 +125,7 @@ TEST_F(TrimN, equalTrim) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         SingleEndRead *per = dynamic_cast<SingleEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
+        trim_n(per->non_const_read_one(), false);
         ASSERT_EQ("GTTTTAGGATT", (per->non_const_read_one()).get_sub_seq());
     }
 };
@@ -124,7 +138,7 @@ TEST_F(TrimN, allN) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         SingleEndRead *per = dynamic_cast<SingleEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
+        trim_n(per->non_const_read_one(), false);
         ASSERT_EQ("N", (per->non_const_read_one()).get_sub_seq());
     }
 };
@@ -138,8 +152,8 @@ TEST_F(TrimN, longN) {
     while(ifp.has_next()) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
-        trim_n(per->non_const_read_one());
-        trim_n(per->non_const_read_two());
+        trim_n(per->non_const_read_one(), false);
+        trim_n(per->non_const_read_two(), false);
         ASSERT_EQ("CTGACTGACTGA", (per->non_const_read_one()).get_sub_seq());
         ASSERT_EQ("ACTGACTGACTGA", (per->non_const_read_two()).get_sub_seq());
     }


### PR DESCRIPTION
Added option --exclude to N_trimmer, if N is found removes the read entirely rather than trim it. Some downstream applications you 1) don't want ANY N character BUT 2) don't want to trim, keeping full 5' to 3' sequence is important.

Specifically this issue is raised in in microbial amplicon preprocessing, where trimming is not desired, but downstream app (dada2) breaks in presence of N