### PR TITLE
Overlapper adapter mods

### DIFF
--- a/common/input_ouput_parameter_map.txt
+++ b/common/input_ouput_parameter_map.txt
@@ -48,11 +48,11 @@ L
   float                       l                   float
   stats-file                  L   Standard        All
 M
-  min-length                  m   Cutting         AdapterTrimmer, CutTrim, NTrimmer, Overlapper, PolyATTrim, QWindowTrim
+  min-length                  m   Cutting         AdapterTrimmer, CutTrim, NTrimmer, PolyATTrim, QWindowTrim
   min-trim                    M                   PolyATTrim
   max-length                  M                   CutTrim
 N
-  no-orphans                  n   Cutting         AdapterTrimmer, CutTrim, NTrimmer, Overlapper, PolyATTrim, QWindowTrim
+  no-orphans                  n   Cutting         AdapterTrimmer, CutTrim, NTrimmer, PolyATTrim, QWindowTrim
   inverse                     n                   SeqScreener
   notes                       N   Standard        All
 O
@@ -71,7 +71,7 @@ R
   record                      r                   SeqScreener
   min_primer_matches          r                   Primers
 S
-  stranded                    s   Cutting         AdapterTrimmer, CutTrim, NTrimmer, Overlapper, PolyATTrim, QWindowTrim
+  stranded                    s   Cutting         AdapterTrimmer, CutTrim, NTrimmer, PolyATTrim, QWindowTrim
   seq                         s                   SeqScreener
   start                       s                   SuperDeduper
 T
@@ -91,6 +91,7 @@ X
   percentage-hits             x                   SeqScreener
   flip                        x                   Primers
   no-fixbases                 X                   AdapterTrimmer
+  force-pairs                 X                   Overlapper
 Y
 Z
   unmapped-output             z   Output          All

--- a/common/src/counters.h
+++ b/common/src/counters.h
@@ -179,6 +179,8 @@ public:
         std::string pad(4 * indent, ' ');
         for (const auto& it : vm) {
             auto& value = it.second.value();
+            //unfortunate hack
+            if ((it.first == "stats-file") & vm.count("append-stats-file")) continue;
             outStats << pad << "\"" << it.first.c_str() << "\": ";
             if (auto v = boost::any_cast<std::string>(&value))
                 outStats << "\"" << *v << "\"";

--- a/common/src/read.h
+++ b/common/src/read.h
@@ -95,18 +95,18 @@ public:
     }
     static char complement(char bp);
 
-    const std::string get_sub_seq() const { return cut_R < cut_L ? "" : seq.substr(cut_L, cut_R - cut_L); }
-    const std::string get_sub_qual() const { return cut_R < cut_L ? "" : qual.substr(cut_L, cut_R - cut_L); }
+    const std::string get_sub_seq() const { return cut_R < cut_L ? "N" : seq.substr(cut_L, cut_R - cut_L); }
+    const std::string get_sub_qual() const { return cut_R < cut_L ? "#" : qual.substr(cut_L, cut_R - cut_L); }
 
 
-    const std::string get_seq_rc() const { if (cut_R < cut_L) { return ""; }
+    const std::string get_seq_rc() const { if (cut_R < cut_L) { return "N"; }
                                            std::string s = seq.substr(cut_L, cut_R - cut_L) ;
                                            std::transform(begin(s), end(s), begin(s), complement);
                                            std::reverse(begin(s), end(s));
                                            return s; }
 
 
-    const std::string get_qual_rc() const { if (cut_R < cut_L) { return ""; }
+    const std::string get_qual_rc() const { if (cut_R < cut_L) { return "#"; }
                                             std::string q = qual.substr(cut_L, cut_R - cut_L);
                                             std::reverse(begin(q), end(q));
                                             return q;  }

--- a/hts_NTrimmer/test/hts_TestNTrimmer.cpp
+++ b/hts_NTrimmer/test/hts_TestNTrimmer.cpp
@@ -28,7 +28,7 @@ TEST_F(TrimN, Exclude) {
         auto i = ifp.next();
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
         nt.trim_n(per->non_const_read_one(), true);
-        ASSERT_EQ("", (per->non_const_read_one()).get_sub_seq());
+        ASSERT_EQ("N", (per->non_const_read_one()).get_sub_seq());
     }
 };
 

--- a/hts_Overlapper/src/hts_Overlapper.h
+++ b/hts_Overlapper/src/hts_Overlapper.h
@@ -22,8 +22,6 @@ public:
     uint64_t sins = 0;
     uint64_t mins = 0;
     uint64_t lins = 0;
-    uint64_t Adapter_Trim = 0;
-    uint64_t Adapter_BpTrim = 0;
 
     uint64_t SE_Discarded = 0;
 
@@ -38,8 +36,6 @@ public:
         fragment.push_back(std::forward_as_tuple("short_inserts", sins));
         fragment.push_back(std::forward_as_tuple("medium_inserts", mins));
         fragment.push_back(std::forward_as_tuple("long_inserts", lins));
-        fragment.push_back(std::forward_as_tuple("adapterTrim", Adapter_Trim));
-        fragment.push_back(std::forward_as_tuple("adapterBpTrim", Adapter_BpTrim));
 
         se.push_back(std::forward_as_tuple("discarded", SE_Discarded));
 
@@ -58,8 +54,6 @@ public:
         } else if (!one.getDiscard() && origLength) { // overlapped read
             if (one.getLength() < origLength) {
                 ++sins; //adapters must be had (short insert)
-                ++Adapter_Trim;
-                Adapter_BpTrim += (origLength - one.getLength());
             } else {
                 ++mins; //must be a long insert
             }

--- a/hts_Overlapper/src/hts_Overlapper.h
+++ b/hts_Overlapper/src/hts_Overlapper.h
@@ -110,7 +110,7 @@ public:
         // check-lengths|c ; min-overlap|o
 
         desc.add_options()
-            ("force-pairs,X", po::bool_switch()->default_value(false), "after overlapping a paired end read, split reads in half to output paired end read.");
+            ("force-pairs,X", po::bool_switch()->default_value(false), "after overlapping a paired end read, split reads in half to output pairs.");
     }
 
     Overlapper() {

--- a/hts_Overlapper/src/hts_Overlapper.h
+++ b/hts_Overlapper/src/hts_Overlapper.h
@@ -288,7 +288,7 @@ public:
                         Read overlappedRead = overlapped->non_const_read_one();
                         double mid = ceil(overlappedRead.getLengthTrue() / 2.0);
                         Read r1(overlappedRead.get_sub_seq().substr(0,mid),overlappedRead.get_sub_qual().substr(0,mid),overlappedRead.get_id());
-                        Read r2(overlappedRead.get_sub_seq().substr(mid,overlappedRead.getLengthTrue()),overlappedRead.get_sub_qual().substr(mid,overlappedRead.getLengthTrue()),overlappedRead.get_id());
+                        Read r2(overlappedRead.get_sub_seq().substr(mid),overlappedRead.get_sub_qual().substr(mid),overlappedRead.get_id());
                         PairedEndRead newper(r1, r2);
                         writer_helper(&newper, pe, se); //write out as is
                     } else {

--- a/hts_Overlapper/src/hts_Overlapper.h
+++ b/hts_Overlapper/src/hts_Overlapper.h
@@ -48,6 +48,7 @@ public:
                 insertLength.resize(one.getLength() + 1);
             }
             ++insertLength[one.getLength()];
+        }
     }
 
     virtual void output(PairedEndRead &per)  {

--- a/hts_Overlapper/src/hts_Overlapper.h
+++ b/hts_Overlapper/src/hts_Overlapper.h
@@ -287,7 +287,7 @@ public:
                     if (forcePair){
                         Read overlappedRead = overlapped->non_const_read_one();
                         double mid = ceil(overlappedRead.getLengthTrue() / 2.0);
-                        Read r1(overlappedRead.get_sub_seq().substr(0,mid),overlappedRead.get_sub_qual().substr(1,mid),overlappedRead.get_id());
+                        Read r1(overlappedRead.get_sub_seq().substr(0,mid),overlappedRead.get_sub_qual().substr(0,mid),overlappedRead.get_id());
                         Read r2(overlappedRead.get_sub_seq().substr(mid,overlappedRead.getLengthTrue()),overlappedRead.get_sub_qual().substr(mid,overlappedRead.getLengthTrue()),overlappedRead.get_id());
                         PairedEndRead newper(r1, r2);
                         writer_helper(&newper, pe, se); //write out as is

--- a/hts_Overlapper/src/hts_Overlapper.h
+++ b/hts_Overlapper/src/hts_Overlapper.h
@@ -278,10 +278,9 @@ public:
                 }
             } else {
                 SingleEndRead* ser = dynamic_cast<SingleEndRead*>(i.get());
-
                 if (ser) {
                     counters.input(*ser);
-                    counters.output(*ser, 0);
+                    counters.output(*ser);
                     writer_helper(ser, pe, se);
                 } else {
                     throw std::runtime_error("Unknown read type");

--- a/hts_PolyATTrim/test/hts_TestPolyATTrim.cpp
+++ b/hts_PolyATTrim/test/hts_TestPolyATTrim.cpp
@@ -74,7 +74,7 @@ TEST_F(PolyATTail, AllTrim) {
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
         pa.trim_left(per->non_const_read_two(), 'A', min_trim, max_trim, window_size, max_mismatch_errorDensity, perfect_windows);
         pa.trim_right(per->non_const_read_two(), 'A', min_trim, max_trim, window_size, max_mismatch_errorDensity, perfect_windows);
-        ASSERT_EQ("", (per->non_const_read_two()).get_sub_seq());
+        ASSERT_EQ("N", (per->non_const_read_two()).get_sub_seq());
     }
 };
 

--- a/hts_Primers/test/hts_TestPrimers.cpp
+++ b/hts_Primers/test/hts_TestPrimers.cpp
@@ -99,7 +99,7 @@ TEST_F(Primer, test_pairs_one_fail) {
         counter.output(*per);
         ASSERT_EQ("", (per->non_const_read_one()).get_sub_seq());
         ASSERT_EQ(301u, (per->non_const_read_one()).getRTrim());
-        ASSERT_EQ("", (per->non_const_read_two()).get_sub_seq());
+        ASSERT_EQ("N", (per->non_const_read_two()).get_sub_seq());
         ASSERT_EQ(301u, (per->non_const_read_two()).getRTrim());
         ASSERT_EQ(0u, counter.flipped);
     }

--- a/hts_QWindowTrim/test/hts_TestQWindowTrim.cpp
+++ b/hts_QWindowTrim/test/hts_TestQWindowTrim.cpp
@@ -86,7 +86,7 @@ TEST_F(QTrimTest, AllTrim) {
         PairedEndRead *per = dynamic_cast<PairedEndRead*>(i.get());
         qt.trim_left(per->non_const_read_two(), sum_qual, window_size);
         qt.trim_right(per->non_const_read_two(), sum_qual, window_size);
-        ASSERT_EQ("", (per->non_const_read_two()).get_sub_qual());
+        ASSERT_EQ("#", (per->non_const_read_two()).get_sub_qual());
     }
 };
 
@@ -114,4 +114,3 @@ TEST_F(QTrimTest, Stranded) {
     }
     ASSERT_EQ("Read1\tGACTTTTTTTTT\tAAAAAAAAAAAA\n", out1->str());
 };
-


### PR DESCRIPTION
Actually no changes to adapter, changes reflective of conversation had around stats reporting

+ Updated overlapper stats, removed a few stats, put short, medium, long in its own block, changed some names.
+ insert/overlapped stats are now relative to input and not output
+ removed Cutting options from overlapper, so no min-length, stranded, no-orphans gone
+ prevented a 0 length read, now if read result 0 length, outputs a N with qual 2 (related to no discard)
+ fix a small issue in counter when append-stats-file is used, stats-file is written out too in parameter block, change to prevent it from doing so
+ added option force-pairs to overlapper, to split a read down the middle (odd length R1, gets extra base). and changed to make sure output is the same.
