### PR TITLE
add basepairs counter (json output) to all apps

### DIFF
--- a/common/src/counters.h
+++ b/common/src/counters.h
@@ -41,9 +41,12 @@ public:
 
     uint64_t SE_In = 0;
     uint64_t SE_Out = 0;
+    uint64_t SE_BpLen = 0;
 
     uint64_t PE_In = 0;
     uint64_t PE_Out = 0;
+    uint64_t R1_BpLen = 0;
+    uint64_t R2_BpLen = 0;
 
     Counters(const std::string &program_name_, po::variables_map vm_):
             pName(program_name_),
@@ -68,6 +71,10 @@ public:
 
         se.push_back(std::forward_as_tuple("in", SE_In));
         se.push_back(std::forward_as_tuple("out", SE_Out));
+        se.push_back(std::forward_as_tuple("total_basepairs", SE_BpLen));
+
+        r1.push_back(std::forward_as_tuple("total_basepairs", R1_BpLen));
+        r2.push_back(std::forward_as_tuple("total_basepairs", R2_BpLen));
 
         pe.push_back(std::forward_as_tuple("in", PE_In));
         pe.push_back(std::forward_as_tuple("out", PE_Out));
@@ -91,13 +98,17 @@ public:
     }
 
     virtual void output(PairedEndRead &read) {
-        (void)read;  //ignore unused variable warning
+        Read &one = read.non_const_read_one();
+        Read &two = read.non_const_read_two();
+        R1_BpLen += one.getLength();
+        R2_BpLen += two.getLength();
         ++PE_Out;
         ++TotalFragmentsOutput;
      }
 
     virtual void output(SingleEndRead &read) {
-        (void)read;  //ignore unused variable warning
+        Read &one = read.non_const_read_one();
+        SE_BpLen += one.getLength();
         ++SE_Out;
         ++TotalFragmentsOutput;
      }

--- a/hts_LengthFilter/src/hts_LengthFilter.h
+++ b/hts_LengthFilter/src/hts_LengthFilter.h
@@ -40,6 +40,7 @@ public:
         if (!one.getDiscard()) {
             ++TotalFragmentsOutput;
             ++SE_Out;
+            SE_BpLen += one.getLength();
         } else {
             ++SE_Discarded;
         }
@@ -51,13 +52,17 @@ public:
         if (!one.getDiscard() && !two.getDiscard()) {
             ++TotalFragmentsOutput;
             ++PE_Out;
+            R1_BpLen += one.getLength();
+            R2_BpLen += two.getLength();
         } else if (!one.getDiscard() && !no_orphans) {
             ++TotalFragmentsOutput;
             ++SE_Out;
+            SE_BpLen += one.getLength();
             ++R2_Discarded;
         } else if (!two.getDiscard() && !no_orphans) {
             ++TotalFragmentsOutput;
             ++SE_Out;
+            SE_BpLen += two.getLength();
             ++R1_Discarded;
         } else {
             ++PE_Discarded;

--- a/hts_SeqScreener/src/hts_SeqScreener.h
+++ b/hts_SeqScreener/src/hts_SeqScreener.h
@@ -92,6 +92,12 @@ public:
 
         start_sublabel("Paired_end");
         write_values(pe, 2);
+        start_sublabel("Read1",2);
+        write_values(r1, 3);
+        end_sublabel(2);
+        start_sublabel("Read2",2);
+        write_values(r2, 3);
+        end_sublabel(2);
         end_sublabel();
 
         finalize_json();

--- a/hts_Stats/src/hts_Stats.h
+++ b/hts_Stats/src/hts_Stats.h
@@ -41,24 +41,17 @@ public:
     uint64_t T = 0;
     uint64_t N = 0;
 
-    uint64_t SE_BpLen = 0;
     uint64_t SE_bQ30 = 0;
 
-    uint64_t R1_BpLen = 0;
     uint64_t R1_bQ30 = 0;
-    uint64_t R2_BpLen = 0;
     uint64_t R2_bQ30 = 0;
 
     StatsCounters(const std::string &program_name, const po::variables_map &vm) : Counters::Counters(program_name, vm) {
         R1_Length.resize(1);
         R2_Length.resize(1);
         SE_Length.resize(1);
-        se.push_back(std::forward_as_tuple("total_basepairs", SE_BpLen));
         se.push_back(std::forward_as_tuple("total_Q30_basepairs", SE_bQ30));
-
-        r1.push_back(std::forward_as_tuple("total_basepairs", R1_BpLen));
         r1.push_back(std::forward_as_tuple("total_Q30_basepairs", R1_bQ30));
-        r2.push_back(std::forward_as_tuple("total_basepairs", R2_BpLen));
         r2.push_back(std::forward_as_tuple("total_Q30_basepairs", R2_bQ30));
 
         bases.push_back(std::forward_as_tuple("A", A));
@@ -68,9 +61,7 @@ public:
         bases.push_back(std::forward_as_tuple("N", N));
     }
 
-    void read_stats(Read &r, uint64_t &BpLen, Vec &Length, Mat &read_bases, Mat &read_qualities, uint64_t &read_bQ30) {
-        // Total length of bases per read
-        BpLen += r.getLength();
+    void read_stats(Read &r, Vec &Length, Mat &read_bases, Mat &read_qualities, uint64_t &read_bQ30) {
         // Size histogram per read
         if ( r.getLength() + 1 > Length.size() ) {
             Length.resize(r.getLength() + 1);
@@ -125,13 +116,13 @@ public:
     using Counters::output;
     void output(PairedEndRead &per) {
         Counters::output(per);
-        read_stats(per.non_const_read_one(), R1_BpLen, R1_Length, R1_bases, R1_qualities, R1_bQ30);
-        read_stats(per.non_const_read_two(), R2_BpLen, R2_Length, R2_bases, R2_qualities, R2_bQ30);
+        read_stats(per.non_const_read_one(), R1_Length, R1_bases, R1_qualities, R1_bQ30);
+        read_stats(per.non_const_read_two(), R2_Length, R2_bases, R2_qualities, R2_bQ30);
     }
 
     void output(SingleEndRead &ser) {
         Counters::output(ser);
-        read_stats(ser.non_const_read_one(), SE_BpLen, SE_Length, SE_bases, SE_qualities, SE_bQ30);
+        read_stats(ser.non_const_read_one(), SE_Length, SE_bases, SE_qualities, SE_bQ30);
     }
 
     void write_out() {

--- a/hts_SuperDeduper/src/hts_SuperDeduper.h
+++ b/hts_SuperDeduper/src/hts_SuperDeduper.h
@@ -71,6 +71,12 @@ public:
 
         start_sublabel("Paired_end");
         write_values(pe, 2);
+        start_sublabel("Read1",2);
+        write_values(r1, 3);
+        end_sublabel(2);
+        start_sublabel("Read2",2);
+        write_values(r2, 3);
+        end_sublabel(2);
         end_sublabel();
 
         finalize_json();


### PR DESCRIPTION
Moved read basepairs counter (total basepairs in SE, R1, R2 )from only in hts_Stats to all applications